### PR TITLE
Allowing keypaths to be strings

### DIFF
--- a/src/evaluator.js
+++ b/src/evaluator.js
@@ -14,7 +14,7 @@ var cloneDeep = require('./utils').cloneDeep
 
 
 /**
- * Dereferences a value, if its a mutable value makes a copy
+ * Dereferences a value by making a copy if it's mutable
  */
 function deref(val) {
   if (isImmutable(val)) {

--- a/src/key-path.js
+++ b/src/key-path.js
@@ -1,5 +1,5 @@
-var isArray = require('./utils').isArray
 var isFunction = require('./utils').isFunction
+var flatten = require('lodash').flatten
 
 /**
  * Checks if something is simply a keyPath and not a getter
@@ -7,8 +7,12 @@ var isFunction = require('./utils').isFunction
  * @return {boolean}
  */
 exports.isKeyPath = function(toTest) {
+
+  // make sure it's an array
+  toTest = flatten([toTest])
+
   return (
-    isArray(toTest) &&
+    toTest.length &&
     !isFunction(toTest[toTest.length - 1])
   )
 }


### PR DESCRIPTION
Opening this PR more to discuss the API than for it to be accepted. (I'd need to update the tests if you like it).

I personally like getters that take the shape of:
`['items', 'taxPercent', function() { ... }]`
`'items'`

more than:
`[ ['items'], function() { ... }]`
`['items']`

It's more in line with other frameworks (namely angular), and would allow for string keypaths to still be valid.

I don't _think_ this change will create too big of a performance hit, and I also don't think it makes the code too confusing, but I'm not sure what the pitfalls to having string keypaths was, either.  @jordangarcia Can you weigh in on this?  We'll also need to update the docs to reflect the decision.