### PR TITLE
Jc utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
     "stateless"
   ],
   "dependencies": {
-    "immutable": "^3.0.x",
-    "lodash": "^2.4.1"
+    "immutable": "^3.0.x"
   },
   "devDependencies": {
+    "lodash": "^2.4.1",
     "jstransform": "^6.2.0",
     "webpack": "^1.4.0-beta4",
     "jstransform-loader": "^0.1.1",

--- a/src/utils.js
+++ b/src/utils.js
@@ -12,8 +12,6 @@ exports.isArray = _.isArray
 
 exports.isFunction = _.isFunction
 
-exports.isString = _.isString
-
 /**
  * Ensures that the inputted value is an array
  * @param {*} val
@@ -32,6 +30,24 @@ exports.coerceArray = function(val) {
  * @return {boolean}
  */
 exports.isNumber = function(val) {
-  return typeof val == 'number' ||
-    val && typeof val == 'object' && toString.call(val) === '[object Number]'
+  return typeof val == 'number' || objectToString(val) === '[object Number]'
+}
+
+/**
+ * Checks if the passed in value is a string
+ * @param {*} val
+ * @return {boolean}
+ */
+exports.isString = function(val) {
+  return typeof val == 'string' || objectToString(val) === '[object String]'
+}
+
+/**
+ * Returns the text value representation of an object
+ * @private
+ * @param {*} obj
+ * @return {string}
+ */
+function objectToString(obj) {
+  return obj && typeof obj == 'object' && toString.call(obj)
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -8,8 +8,6 @@ exports.each = _.each
 
 exports.partial = _.partial
 
-exports.isFunction = _.isFunction
-
 /**
  * Ensures that the inputted value is an array
  * @param {*} val
@@ -47,6 +45,15 @@ exports.isString = function(val) {
  */
 exports.isArray = Array.isArray || function(val) {
   return objectToString(val) === '[object Array]'
+}
+
+/**
+ * Checks if the passed in value is a function
+ * @param {*} val
+ * @return {boolean}
+ */
+exports.isFunction = function(val) {
+  return toString.call(val) === '[object Function]'
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,5 @@
 var _ = require('lodash');
 
-exports.each = _.each
-
 exports.partial = _.partial
 
 /**
@@ -98,6 +96,43 @@ exports.clone = function(obj) {
 }
 
 /**
+ * Iterates over a collection of elements yielding each iteration to an
+ * iteratee. The iteratee may be bound to the context argument and is invoked
+ * each time with three arguments (value, index|key, collection). Iteration may
+ * be exited early by explicitly returning false.
+ * @param {array|object|string} collection
+ * @param {function} iteratee
+ * @param {*} context
+ * @return {array|object|string}
+ */
+exports.each = function(collection, iteratee, context) {
+  var length = collection ? collection.length : 0
+  var i = -1
+  var keys, origIteratee
+
+  if (context) {
+    origIteratee = iteratee
+    iteratee = function(value, index, collection) {
+      return origIteratee.call(context, value, index, collection)
+    }
+  }
+
+  if (isLength(length)) {
+    while (++i < length) {
+      if (iteratee(collection[i], i, collection) === false) break
+    }
+  } else {
+    keys = Object.keys(collection)
+    length = keys.length
+    while (++i < length) {
+      if (iteratee(collection[keys[i]], keys[i], collection) === false) break
+    }
+  }
+
+  return collection
+}
+
+/**
  * Returns the text value representation of an object
  * @private
  * @param {*} obj
@@ -105,4 +140,17 @@ exports.clone = function(obj) {
  */
 function objectToString(obj) {
   return obj && typeof obj == 'object' && toString.call(obj)
+}
+
+/**
+ * Checks if the value is a valid array-like length.
+ * @private
+ * @param {*} val
+ * @return {bool}
+ */
+function isLength(val) {
+  return typeof val == 'number'
+    && val > -1
+    && val % 1 == 0
+    && val <= Number.MAX_SAFE_INTEGER
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -14,8 +14,6 @@ exports.isFunction = _.isFunction
 
 exports.isString = _.isString
 
-exports.isNumber = _.isNumber
-
 /**
  * Ensures that the inputted value is an array
  * @param {*} val
@@ -26,4 +24,14 @@ exports.coerceArray = function(val) {
     return [val]
   }
   return val
+}
+
+/**
+ * Checks if the passed in value is a number
+ * @param {*} val
+ * @return {boolean}
+ */
+exports.isNumber = function(val) {
+  return typeof val == 'number' ||
+    val && typeof val == 'object' && toString.call(val) === '[object Number]'
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -55,6 +55,15 @@ exports.isFunction = function(val) {
 }
 
 /**
+ * Checks if the passed in value is af type Object
+ * @param {*} val
+ * @return {boolean}
+ */
+exports.isObject = function(obj) {
+  var type = typeof obj
+  return type === 'function' || type === 'object' && !!obj
+}
+
  * Extends an object with the properties of additional objects
  * @param {object} obj
  * @param {object} objects

--- a/src/utils.js
+++ b/src/utils.js
@@ -8,8 +8,6 @@ exports.each = _.each
 
 exports.partial = _.partial
 
-exports.isArray = _.isArray
-
 exports.isFunction = _.isFunction
 
 /**
@@ -40,6 +38,15 @@ exports.isNumber = function(val) {
  */
 exports.isString = function(val) {
   return typeof val == 'string' || objectToString(val) === '[object String]'
+}
+
+/**
+ * Checks if the passed in value is an array
+ * @param {*} val
+ * @return {boolean}
+ */
+exports.isArray = Array.isArray || function(val) {
+  return objectToString(val) === '[object Array]'
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,5 @@
 var _ = require('lodash');
 
-exports.clone = _.clone
-
 exports.each = _.each
 
 exports.partial = _.partial
@@ -64,6 +62,7 @@ exports.isObject = function(obj) {
   return type === 'function' || type === 'object' && !!obj
 }
 
+/**
  * Extends an object with the properties of additional objects
  * @param {object} obj
  * @param {object} objects
@@ -86,6 +85,16 @@ exports.extend = function(obj) {
   }
 
   return obj
+}
+
+/**
+ * Creates a shallow clone of an object
+ * @param {object} obj
+ * @return {object}
+ */
+exports.clone = function(obj) {
+  if (!exports.isObject(obj)) return obj
+  return exports.isArray(obj) ? obj.slice() : exports.extend({}, obj)
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,8 +2,6 @@ var _ = require('lodash');
 
 exports.clone = _.clone
 
-exports.extend = _.extend
-
 exports.each = _.each
 
 exports.partial = _.partial
@@ -54,6 +52,31 @@ exports.isArray = Array.isArray || function(val) {
  */
 exports.isFunction = function(val) {
   return toString.call(val) === '[object Function]'
+}
+
+/**
+ * Extends an object with the properties of additional objects
+ * @param {object} obj
+ * @param {object} objects
+ * @return {object}
+ */
+exports.extend = function(obj) {
+  var length = arguments.length
+
+  if (!obj || length < 2) return obj || {}
+
+  for (var index = 1; index < length; index++) {
+    var source = arguments[index]
+    var keys = Object.keys(source)
+    var l = keys.length
+
+    for (var i = 0; i < l; i++) {
+      var key = keys[i]
+      obj[key] = source[key]
+    }
+  }
+
+  return obj
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,3 @@
-var _ = require('lodash');
-
-exports.partial = _.partial
-
 /**
  * Ensures that the inputted value is an array
  * @param {*} val
@@ -130,6 +126,23 @@ exports.each = function(collection, iteratee, context) {
   }
 
   return collection
+}
+
+/**
+ * Returns a new function the invokes `func` with `partialArgs` prepended to
+ * any passed into the new function. Acts like `Array.prototype.bind`, except
+ * it does not alter `this` context.
+ * @param {function} func
+ * @param {*} partialArgs
+ * @return {function}
+ */
+exports.partial = function(func) {
+  var slice = Array.prototype.slice
+  var partialArgs = slice.call(arguments, 1)
+
+  return function() {
+    return func.apply(this, partialArgs.concat(slice.call(arguments)))
+  }
 }
 
 /**

--- a/tests/utils-tests.js
+++ b/tests/utils-tests.js
@@ -130,6 +130,7 @@ describe('Utils', () => {
       expect(Utils.isObject(new Boolean(''))).toBe(true)
     })
   })
+
   describe('#extend', () => {
     it('extends an object with the attributes of another', () => {
       expect(Utils.extend({}, { a: 1 })).toEqual({ a: 1 })
@@ -179,6 +180,42 @@ describe('Utils', () => {
       F.prototype = { a: 1 }
       var obj = new F()
       expect(Utils.extend({ a: 10 }).a).toEqual(10)
+    })
+  })
+
+  describe('#clone', () => {
+    it('clones a simple array', () => {
+      var arr = [1, 2, 3]
+      var result = Utils.clone(arr)
+      expect(result).toEqual(arr)
+    })
+
+    it('clones object literals', () => {
+      var obj = { a: 1, b: 2, c: 3  }
+      var result = Utils.clone(obj)
+      expect(result).toEqual(obj)
+    })
+
+    it('does not share shallow attributes between objects', () => {
+      var obj = { a: 1 }
+      var result = Utils.clone(obj)
+      result.a = 10
+      expect(obj.a === 1 && result.a === 10).toBe(true)
+    })
+
+    it('shares changes to deep attributes between objects', () => {
+      var obj = { a: 1, b: 2, c: [1, 2, 3] }
+      var result = Utils.clone(obj)
+      result.c.push(4)
+      expect(obj.c[obj.c.length - 1]).toBe(4)
+    })
+
+    it('does not clone non objects', () => {
+      expect(Utils.clone(1)).toBe(1)
+      expect(Utils.clone(undefined)).toBe(void 0)
+      expect(Utils.clone('some string')).toBe('some string')
+      expect(Utils.clone(null)).toBe(null)
+      expect(Utils.clone(true)).toBe(true)
     })
   })
 })

--- a/tests/utils-tests.js
+++ b/tests/utils-tests.js
@@ -37,4 +37,16 @@ describe('Utils', () => {
       expect(result).toBe(true)
     })
   })
+
+  describe('#isString', () => {
+    it('correctly identifies a non-string as not a string', () => {
+      var result = Utils.isString(1)
+      expect(result).toBe(false)
+    })
+
+    it('correctly identifies a string as a string', () => {
+      var result = Utils.isString('string')
+      expect(result).toBe(true)
+    })
+  })
 })

--- a/tests/utils-tests.js
+++ b/tests/utils-tests.js
@@ -66,4 +66,32 @@ describe('Utils', () => {
       expect(result).toBe(true)
     })
   })
+
+  describe('#isFunction', () => {
+    it('correctly identifies a non-function as not a function', () => {
+      var result = Utils.isFunction(1)
+      expect(result).toBe(false)
+    })
+
+    it('correctly identifies a RegEx as not a function', () => {
+      var result = Utils.isFunction(/something/)
+      expect(result).toBe(false)
+    })
+
+    it('correctly identifies a function decleration as a function', () => {
+      var result = Utils.isFunction(()=>{})
+      expect(result).toBe(true)
+    })
+
+    it('correctly identifies a function expression as a function', () => {
+      var testCase = () => {}
+      var result = Utils.isFunction(testCase)
+      expect(result).toBe(true)
+    })
+
+    it('correctly identifies a method as a function', () => {
+      var result = Utils.isFunction(Utils.isFunction)
+      expect(result).toBe(true)
+    })
+  })
 })

--- a/tests/utils-tests.js
+++ b/tests/utils-tests.js
@@ -94,4 +94,56 @@ describe('Utils', () => {
       expect(result).toBe(true)
     })
   })
+
+  describe('#extend', () => {
+    it('extends an object with the attributes of another', () => {
+      expect(Utils.extend({}, { a: 1 })).toEqual({ a: 1 })
+    })
+
+    it('overrides source properties with destination properties', () => {
+      expect(Utils.extend({ a: 1 }, { a: 2 }).a).toBe(2)
+    })
+
+    it('maintains destination properties not in source', () => {
+      expect(Utils.extend({ a: 1 }, { b: 2 }).a).toBeDefined()
+    })
+
+    it('can extend from multiple sources', () => {
+      var result = Utils.extend({ a: 1 }, { b: 2 }, { c: 3})
+      expect(result).toEqual({ a: 1, b: 2, c: 3})
+    })
+
+    it('sets property priority from right to left', () => {
+      var result = Utils.extend({ a: 1 }, { a: 2, b: 2 }, { b: 3 })
+      expect(result).toEqual({ a: 2, b: 3 })
+    })
+
+    it('skips over non-plain objects', () => {
+      var result = Utils.extend({ a: 1 }, /something/, { b: 2 })
+      expect(result).toEqual({ a: 1, b: 2 })
+    })
+
+    it('returns an empty object when arguments are not defined', () => {
+      expect(Utils.extend()).toEqual({})
+    })
+
+    it('returns the original object when only one argument is passed', () => {
+      var obj = {}
+      expect(Utils.extend(obj)).toBe(obj)
+    })
+
+    it('copies all properties from source', () => {
+      var obj = { a: 1 }
+      obj.b = 2
+      expect(Utils.extend({}, obj).a).toBe(1)
+      expect(Utils.extend({}, obj).b).toBe(2)
+    })
+
+    it('does not extend inherited properties', () => {
+      var F = function() {}
+      F.prototype = { a: 1 }
+      var obj = new F()
+      expect(Utils.extend({ a: 10 }).a).toEqual(10)
+    })
+  })
 })

--- a/tests/utils-tests.js
+++ b/tests/utils-tests.js
@@ -95,6 +95,41 @@ describe('Utils', () => {
     })
   })
 
+  describe('#isObject', () => {
+    it('identifies an array as an Object type', () => {
+      expect(Utils.isObject([])).toBe(true)
+    })
+
+    it('identifies an object literal as an Object type', () => {
+      expect(Utils.isObject({})).toBe(true)
+    })
+
+    it('identifies the arguments object as an Object type', () => {
+      expect(Utils.isObject(arguments)).toBe(true)
+    })
+
+    it('identifies a function as an Object type', () => {
+      expect(Utils.isObject(()=>{})).toBe(true)
+    })
+
+    it('identifies a regex as an Object type', () => {
+      expect(Utils.isObject(/something/)).toBe(true)
+    })
+
+    it('identifies primitives and non-objects as not of type Object', () => {
+      expect(Utils.isObject(1)).not.toBe(true)
+      expect(Utils.isObject('something')).not.toBe(true)
+      expect(Utils.isObject(false)).not.toBe(true)
+      expect(Utils.isObject(void 0)).not.toBe(true)
+      expect(Utils.isObject(null)).not.toBe(true)
+    })
+
+    it('identifies instances as Object types', () => {
+      expect(Utils.isObject(new Number(0))).toBe(true)
+      expect(Utils.isObject(new String(''))).toBe(true)
+      expect(Utils.isObject(new Boolean(''))).toBe(true)
+    })
+  })
   describe('#extend', () => {
     it('extends an object with the attributes of another', () => {
       expect(Utils.extend({}, { a: 1 })).toEqual({ a: 1 })

--- a/tests/utils-tests.js
+++ b/tests/utils-tests.js
@@ -1,0 +1,40 @@
+var Utils = require('../src/utils')
+
+describe('Utils', () => {
+  describe('#isNumber', () => {
+    it('correctly identifies number strings as not numbers', () => {
+      var result = Utils.isNumber('1')
+      expect(result).toBe(false)
+    })
+
+    it('correctly identifies integers as numbers', () => {
+      var result = Utils.isNumber(1)
+      expect(result).toBe(true)
+    })
+
+    it('correctly identifies floats as numbers', () => {
+      var result = Utils.isNumber(1.5)
+      expect(result).toBe(true)
+    })
+
+    it('correctly identifies NaN as a number', () => {
+      var result = Utils.isNumber(NaN)
+      expect(result).toBe(true)
+    })
+
+    it('correctly identifies number instances as numbers', () => {
+      var result = Utils.isNumber(new Number(1))
+      expect(result).toBe(true)
+    })
+
+    it('correctly identifies scientific notation as a number', () => {
+      var result = Utils.isNumber(10e2)
+      expect(result).toBe(true)
+    })
+
+    it('correctly identifies hexadecimals as numbers', () => {
+      var result = Utils.isNumber(0xff)
+      expect(result).toBe(true)
+    })
+  })
+})

--- a/tests/utils-tests.js
+++ b/tests/utils-tests.js
@@ -49,4 +49,21 @@ describe('Utils', () => {
       expect(result).toBe(true)
     })
   })
+
+  describe('#isArray', () => {
+    it('correctly identifies a non-array as not an array', () => {
+      var result = Utils.isArray(1)
+      expect(result).toBe(false)
+    })
+
+    it('correctly identifies an array literal as an array', () => {
+      var result = Utils.isArray([])
+      expect(result).toBe(true)
+    })
+
+    it('correctly identifies an array instance as an array', () => {
+      var result = Utils.isArray(new Array())
+      expect(result).toBe(true)
+    })
+  })
 })

--- a/tests/utils-tests.js
+++ b/tests/utils-tests.js
@@ -313,4 +313,21 @@ describe('Utils', () => {
       expect(Utils.each(once, ()=>{})).toBe(once)
     })
   })
+
+  describe('#partial', () => {
+    it('partially applies function arguments', () => {
+      var func = (greeting, name) => greeting + ' ' + name
+      var result = Utils.partial(func, 'hello')
+      expect(result('nuclear')).toBe('hello nuclear')
+    })
+
+    it('does not alter context', () => {
+      var obj = { name: 'nuclear' }
+      var func = function(greeting, mark) {
+        return greeting + ' ' + this.name + mark
+      }
+      obj.greet = Utils.partial(func, 'hello')
+      expect(obj.greet('!')).toBe('hello nuclear!')
+    })
+  })
 })


### PR DESCRIPTION
closes #18 

Drops lodash as a dependency. The utils module has been replaced with plain javascript implementations of the original lodash functions.

I've tried to keep as true to lodash as possible with the function signatures, to prevent any gotchas, and the tests follow many of the same assertions that lodash/underscore make.

The one noticeable difference in utils api exists in `Utils#partial`, which does not accept placeholder values like the lodash implementation does. I decided to leave it out because it wasn't being used in the Nuclear source, and, in my opinion, it makes the function implementation more convoluted.

Happy to get thoughts/feedback on this.

@jordangarcia @dshimkoski @dtothefp 