### PR TITLE
Attempt at fixing grunt test, phantomJS error.

### DIFF
--- a/grunt/karma.js
+++ b/grunt/karma.js
@@ -40,7 +40,6 @@ module.exports = {
   },
 
   phantom: {
-    configFile: 'grunt/karma-configs/phantom.karma.js',
     frameworks: ['jasmine', 'es5-shim'],
     browsers: ['PhantomJS'],
   },


### PR DESCRIPTION
We were previously pointing to a config file that didn't exist. This fixes #66.

```js
Running "karma:phantom" (karma) task
ERROR [config]: File /Users/bhamodi/work/nuclear-js/grunt/karma-configs/phantom.karma.js does not exist!
```

This change removes the configFile attribute, and now the command `grunt test` passes successfully. @jordangarcia 