### PR TITLE
Reactor unobserve

### DIFF
--- a/src/getter.js
+++ b/src/getter.js
@@ -48,10 +48,21 @@ function fromKeyPath(keyPath) {
   return [keyPath, identity]
 }
 
+/**
+ * Determines if a getter was converted from a plain KeyPath, ex. ['a', 'b'],
+ * using Getter.fromKeyPath
+ * @param {Getter}
+ * @return {boolean}
+ */
+function wasKeyPath(getter) {
+  return getComputeFn(getter) === identity
+}
+
 
 module.exports = {
   isGetter: isGetter,
   getComputeFn: getComputeFn,
   getDeps: getDeps,
   fromKeyPath: fromKeyPath,
+  wasKeyPath: wasKeyPath,
 }

--- a/src/key-path.js
+++ b/src/key-path.js
@@ -6,9 +6,39 @@ var isFunction = require('./utils').isFunction
  * @param {*} toTest
  * @return {boolean}
  */
-exports.isKeyPath = function(toTest) {
+var isKeyPath = exports.isKeyPath = function isKeyPath(toTest) {
   return (
     isArray(toTest) &&
     !isFunction(toTest[toTest.length - 1])
   )
+}
+
+/**
+ * Determines if two keyPaths reference the same key
+ * @param {array} keyPath
+ * @param {array} otherKeyPath
+ * @return {boolean}
+ * @example
+ * same(['some', 'keypath'], ['some', 'keypath']) // => true
+ * same(['some', 'keypath'], ['another', 'keypath']) // => false
+ */
+exports.same = function same(keyPath, otherKeyPath) {
+  if (!isKeyPath(keyPath) || !isKeyPath(otherKeyPath)) {
+    return false
+  }
+
+  var len
+  var i = len = keyPath.length
+
+  if (len !== otherKeyPath.length) {
+    return false
+  }
+
+  while (i--) {
+    if (keyPath[i] !== otherKeyPath[i]) {
+      return false
+    }
+  }
+
+  return true
 }

--- a/src/key-path.js
+++ b/src/key-path.js
@@ -42,3 +42,35 @@ exports.same = function same(keyPath, otherKeyPath) {
 
   return true
 }
+
+/**
+ * Determines if a keyPath references a key that is upstream to another keyPath
+ * @param {array} keyPath
+ * @param {array} downstreamKeyPath
+ * @return {boolean}
+ * @example
+ * isUpstream(['some', 'keypath'], ['some', 'keypath', 'with depth']) // => true
+ * isUpstream(['some', 'keypath'], ['some', 'other', 'keypath']) // => false
+ */
+exports.isUpstream = function isUpstream(keyPath, downstreamKeyPath) {
+  if (!isKeyPath(keyPath) || !isKeyPath(downstreamKeyPath)) {
+    return false
+  }
+
+  var i = 0
+  var len = keyPath.length
+
+  if (len >= downstreamKeyPath.length) {
+    return false
+  }
+
+  while (i < len) {
+    if (keyPath[i] !== downstreamKeyPath[i]) {
+      return false
+    }
+
+    i++
+  }
+
+  return true
+}

--- a/src/reactor.js
+++ b/src/reactor.js
@@ -101,6 +101,20 @@ class Reactor {
     return this.__changeObserver.onChange(getter, handler)
   }
 
+  /**
+   * Removes a change observer that has previously been set
+   *
+   * 1. unobserve(keyPath) Removes all observables for keyPath
+   * 2. unobserve(getter) Removes all observables for getter and getter dependencies
+   * 3. unobserve(keyPath|getter, handlerFn) Removes the specific handlerFn for
+   *    the passed in keyPath or getter.
+   *
+   * @param {KeyPath|Getter} getter
+   * @param {function} handler
+   */
+  unobserve(getter, handler) {
+    this.__changeObserver.unwatch(getter, handler)
+  }
 
   /**
    * Dispatches a single message

--- a/tests/getter-tests.js
+++ b/tests/getter-tests.js
@@ -31,4 +31,16 @@ describe('Getter', () => {
       }).toThrow()
     })
   })
+
+  describe('wasKeyPath', () => {
+    it('should return true if a KeyPath was converted to a getter', () => {
+      var getter = Getter.fromKeyPath(['foo'])
+      expect(Getter.wasKeyPath(getter)).toBe(true)
+    })
+
+    it('should return false for a non-converted getter', () => {
+      var getter = [['foo'], ['bar'], (foo, bar) => foo + bar]
+      expect(Getter.wasKeyPath(getter)).toBe(false)
+    })
+  })
 })

--- a/tests/key-path-tests.js
+++ b/tests/key-path-tests.js
@@ -1,6 +1,7 @@
 var Immutable = require('immutable')
 var KeyPath = require('../src/key-path')
 var isKeyPath = KeyPath.isKeyPath
+var same = KeyPath.same
 
 describe('KeyPath', () => {
   describe('isKeyPath', () => {
@@ -25,6 +26,22 @@ describe('KeyPath', () => {
       })
 
       expect(isKeyPath([immMap])).toBe(true)
+    })
+  })
+
+  describe('same', () => {
+    it('should return false when a non-keypath is passed', () => {
+      expect(same(['some', 'keypath'], 'something else')).toBe(false)
+      expect(same({ something: 'else' }, ['some', 'keypath'])).toBe(false)
+    })
+
+    it('should return false when two differnt keypaths are compared', () => {
+      expect(same(['some', 'keypath'], ['some', 'other', 'keypath'])).toBe(false)
+      expect(same(['some', 'keypath'], ['something', 'else'])).toBe(false)
+    })
+
+    it('should return true when the same keypath is compared', () => {
+      expect(same(['some', 'keypath'], ['some', 'keypath'])).toBe(true)
     })
   })
 })

--- a/tests/key-path-tests.js
+++ b/tests/key-path-tests.js
@@ -2,6 +2,7 @@ var Immutable = require('immutable')
 var KeyPath = require('../src/key-path')
 var isKeyPath = KeyPath.isKeyPath
 var same = KeyPath.same
+var isUpstream = KeyPath.isUpstream
 
 describe('KeyPath', () => {
   describe('isKeyPath', () => {
@@ -42,6 +43,23 @@ describe('KeyPath', () => {
 
     it('should return true when the same keypath is compared', () => {
       expect(same(['some', 'keypath'], ['some', 'keypath'])).toBe(true)
+    })
+  })
+
+  describe('isUpstream', () => {
+    it('should return false when a non-keypath is passed', () => {
+      expect(isUpstream(['some', 'keypath'], 'something else')).toBe(false)
+      expect(isUpstream({ something: 'else' }, ['some', 'keypath'])).toBe(false)
+    })
+
+    it('should return false when two unrelated keypaths are passed', () => {
+      expect(isUpstream(['some', 'keypath'], ['some', 'other', 'keypath'])).toBe(false)
+      expect(isUpstream(['some', 'keypath'], ['something', 'else'])).toBe(false)
+    })
+
+    it('should return true when two related keypaths are passed', () => {
+      expect(isUpstream(['some', 'keypath'], ['some', 'keypath', 'with depth'])).toBe(true)
+      expect(isUpstream(['some'], ['some', 'keypath', 'with depth'])).toBe(true)
     })
   })
 })

--- a/tests/reactor-tests.js
+++ b/tests/reactor-tests.js
@@ -285,6 +285,80 @@ describe('Reactor', () => {
         expect(mockFn.calls.count()).toEqual(0)
       })
     })
+
+    describe('#unobserve', () => {
+      var mockFn
+
+      beforeEach(() => {
+        mockFn = jasmine.createSpy()
+      })
+
+      describe('when a keypath is passed', () => {
+        beforeEach(() => {
+          reactor.observe(['taxPercent'], mockFn)
+        })
+
+        it('should remove the change handler for the passed in keyPath', () => {
+          reactor.unobserve(['taxPercent'])
+          checkoutActions.setTaxPercent(5)
+
+          expect(mockFn.calls.count()).toEqual(0)
+        })
+
+        describe('when a handler is specified', () => {
+          it('should remove the specific change handler for the keyPath', () => {
+            reactor.unobserve(['taxPercent'], mockFn)
+            checkoutActions.setTaxPercent(5)
+
+            expect(mockFn.calls.count()).toEqual(0)
+          })
+
+          it('should not remove other change handlers for the same keypath', () => {
+            var otherMockFn = jasmine.createSpy()
+            reactor.observe(['taxPercent'], otherMockFn)
+
+            reactor.unobserve(['taxPercent'], mockFn)
+            checkoutActions.setTaxPercent(5)
+
+            expect(otherMockFn.calls.count()).toBe(1)
+          })
+        })
+      })
+
+      describe('when a getter is passed', () => {
+        var otherMockFn
+
+        beforeEach(() => {
+          checkoutActions.addItem('item', 100)
+          reactor.observe(totalGetter, mockFn)
+          otherMockFn = jasmine.createSpy()
+          reactor.observe(totalGetter, otherMockFn)
+        })
+
+        it('should remove the change handler for the getter and deps', () => {
+          reactor.unobserve(totalGetter)
+          checkoutActions.setTaxPercent(5)
+
+          expect(mockFn.calls.count()).toEqual(0)
+          expect(otherMockFn.calls.count()).toEqual(0)
+        })
+
+        describe('when a handler is specified', () => {
+          beforeEach(() => {
+            reactor.unobserve(totalGetter, mockFn)
+            checkoutActions.setTaxPercent(5)
+          })
+
+          it('should remove the specific change handler for the getter', () => {
+            expect(mockFn.calls.count()).toEqual(0)
+          })
+
+          it('should not remove other change handlers for the same getter', () => {
+            expect(otherMockFn.calls.count()).toBe(1)
+          })
+        })
+      })
+    })
   }) // Reactor with no initial state
 
   describe('reactor#reset', () => {


### PR DESCRIPTION
Creates reactor#unobserve and KeyPath.eql, which tests if two keypaths are the same.