### PR TITLE
Action handlers error handling

### DIFF
--- a/src/reactor.js
+++ b/src/reactor.js
@@ -247,15 +247,17 @@ class Reactor {
 
       // let each core handle the message
       this.__stores.forEach((store, id) => {
-        var currState = state.get(id), newState, dispatchError
-         
+        var currState = state.get(id)
+        var newState
+        var dispatchError
+
         try {
           newState = store.handle(currState, actionType, payload)
         } catch(e) {
           dispatchError = e
         }
- 
-        if (this.debug &&  (newState === undefined || dispatchError)) {
+
+        if (this.debug && (newState === undefined || dispatchError)) {
           var error = dispatchError || 'Store handler must return a value, did you forget a return statement'
           logging.dispatchError(error)
           throw new Error(error)

--- a/src/reactor.js
+++ b/src/reactor.js
@@ -247,11 +247,16 @@ class Reactor {
 
       // let each core handle the message
       this.__stores.forEach((store, id) => {
-        var currState = state.get(id)
-        var newState = store.handle(currState, actionType, payload)
-
-        if (this.debug && newState === undefined) {
-          var error = 'Store handler must return a value, did you forget a return statement'
+        var currState = state.get(id), newState, dispatchError
+         
+        try {
+          newState = store.handle(currState, actionType, payload)
+        } catch(e) {
+          dispatchError = e
+        }
+ 
+        if (this.debug &&  (newState === undefined || dispatchError)) {
+          var error = dispatchError || 'Store handler must return a value, did you forget a return statement'
           logging.dispatchError(error)
           throw new Error(error)
         }


### PR DESCRIPTION
console.group is now closing correctly if the error was thrown from the Action handler