### PR TITLE
Add bower support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,33 @@
+{
+  "name": "nuclear-js",
+  "version": "1.1.0",
+  "homepage": "https://github.com/optimizely/nuclear-js",
+  "authors": [
+    "Jordan Garcia"
+  ],
+  "description": "Immutable, reactive Flux architecture. UI Agnostic.",
+  "main": "dist/nuclear.js",
+  "moduleType": [
+    "amd",
+    "globals",
+    "node"
+  ],
+  "keywords": [
+    "flux",
+    "nuclear",
+    "immutable",
+    "react",
+    "vue",
+    "vuejs",
+    "functional",
+    "stateless"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
We want to use nuclear.js in a Rails app, but currently we're using rails-assets.org to pull in and manage javascript module dependencies. rails-assets.org works by wrapping bower modules, so I'm submitting this PR to add a bower.json config file to the project so it'll be available in bower and thus available in rails-assets.org. Thanks!