### PR TITLE
Implemented state awareness for the sidebar.

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -8,4 +8,4 @@
 - [ ] scaffold design patterns/examples area
 - [ ] mobile side navbar
 - [ ] build pipeline for examples, create example component, possibly with code editing
-- [ ] add active state to Docs side bar. (currently doesn't show which tab is active/selected)
+- [x] add active state to Docs side bar. (currently doesn't show which tab is active/selected)

--- a/docs/sass/main.scss
+++ b/docs/sass/main.scss
@@ -255,7 +255,12 @@ pre code.hljs {
 .sidebar-links {
   &--item {
     line-height: 1.2em;
+    margin-top: 1em;
     margin-bottom: 1em;
+  }
+  &--item-active {
+    background-color: #E8E4E4;
+    padding: 1em;
   }
 }
 

--- a/docs/src/main.js
+++ b/docs/src/main.js
@@ -6,9 +6,24 @@ addScrollClass("scrolled")
 
 render(ItemFilterExample, 'item-filter-example')
 
+updateSideBar()
+
 function render(component, id) {
   var el = document.getElementById(id)
   if (el) {
     React.render(React.createElement(ItemFilterExample), el)
+  }
+}
+
+function updateSideBar() {
+  var sideBarElements = document.getElementsByClassName('sidebar-links--item')
+  for (var i in sideBarElements) {
+    if (sideBarElements[i].firstChild) {
+      if (window.location.href === sideBarElements[i].firstChild.href) {
+        sideBarElements[i].className = 'sidebar-links--item-active'
+      } else {
+        sideBarElements[i].className = 'sidebar-links--item'
+      }
+    }
   }
 }


### PR DESCRIPTION
@jordangarcia - This PR adds state awareness for the sidebar. :)

New look:
<img width="1246" alt="screen shot 2015-07-30 at 3 29 32 pm" src="https://cloud.githubusercontent.com/assets/7663987/8996852/366f461c-36d0-11e5-9544-52da4c60e16e.png">

In the future, it would be nice to do this while the content is being dynamically generated but I couldn't get the current url successfully in the isomorphic (server-side) generation step. Could be a future TODO.