### PR TITLE
Adjust notifyObservers iteration when unwatch function is called during iteration [Fixes #151]

### DIFF
--- a/tests/change-observer-tests.js
+++ b/tests/change-observer-tests.js
@@ -78,6 +78,17 @@ describe('ChangeObserver', () => {
         expect(mockFn2.calls.count()).toBe(1)
       })
     })
+
+    it('should not skip observers when handler causes unobserve', () => {
+      var getter = ['foo', 'bar']
+      var mockFn = jasmine.createSpy()
+      var unreg = observer.onChange(getter, () => unreg())
+      observer.onChange(getter, mockFn)
+
+      observer.notifyObservers(initialState.updateIn(getter, x => 2))
+
+      expect(mockFn.calls.count()).toBe(1)
+    })
   })
   // TODO: test the prevValues and registering an observable
 })


### PR DESCRIPTION
Proposed fix for #151.

This PR takes the somewhat ugly approach of reading/modifying the notifyObservers iteration from within the unwatch function. This won't work if notify loops can be nested, but I don't think that is possible/allowed?

The cleaner approach of taking a copy of `__observers` to iterate would mean that observers later in the array that might be unsubscribed during the iteration would still receive a notification.

(Might cause conflict with merging #115 which touches the same code, but retains the same bug.)