### PR TITLE
Add json-loader dependency in shopping cart example

### DIFF
--- a/examples/shopping-cart/package.json
+++ b/examples/shopping-cart/package.json
@@ -16,7 +16,8 @@
     "node-libs-browser": "^0.5.2",
     "webpack": "^1.9.11",
     "babel-core": "^5.6.1",
-    "babel-loader": "^5.1.4"
+    "babel-loader": "^5.1.4",
+    "json-loader": "^0.5.2"
   },
   "name": "shopping-cart-example",
   "version": "0.0.1",


### PR DESCRIPTION
Otherwise webpack fails because of this:

```js
var _products = require('./products.json');
```