### PR TITLE
add missing handler for JSON file types in isomorphic flux chat example

### DIFF
--- a/examples/isomorphic-flux-chat/package.json
+++ b/examples/isomorphic-flux-chat/package.json
@@ -6,6 +6,7 @@
   "author": "Jordan Garcia",
   "license": "ISC",
   "dependencies": {
+    "json-loader": "^0.5.3",
     "keymirror": "^0.1.1",
     "nuclear-js": "^1.1.1",
     "nuclear-js-react-addons": "jordangarcia/nuclear-js-react-addons#051c39b10c4af9af7007216b06fccbdf79994529",

--- a/examples/isomorphic-flux-chat/webpack.config.js
+++ b/examples/isomorphic-flux-chat/webpack.config.js
@@ -55,6 +55,9 @@ module.exports = [{
       // don't try to load them ... just make the require calls not break
       test: /\.css$/,
       loader: 'css',
+    }, {
+      test: /\.json$/,
+      loader: "json-loader"
     }],
   },
 


### PR DESCRIPTION
Fixes the following issue when running `npm run build` in the **Isomorphic Flux Chat Example**
```
ERROR in ./~/yargs/~/os-locale/~/lcid/lcid.json
    Module parse failed: /Users/joe/tmp/nuclear-js/examples/isomorphic-flux-chat/node_modules/yargs/node_modules/os-locale/node_modules/lcid/lcid.json Line 2: Unexpected token :
    You may need an appropriate loader to handle this file type.
    | {
    | 	"af_ZA": 1078,
    | 	"am_ET": 1118,
    | 	"ar_AE": 14337,
     @ ./~/yargs/~/os-locale/~/lcid/index.js 3:10-32
```