### PR TITLE
Fix the broken link on the actions->async_actions docs.

### DIFF
--- a/docs/src/docs/02-creating-actions.md
+++ b/docs/src/docs/02-creating-actions.md
@@ -62,7 +62,7 @@ While synchronous actions are great, often you'll need to perform an asynchronou
 fully supports creating actions asynchronously, as we're doing in `fetchProducts`.  This is a common pattern you'll use as your application grows,
 and NuclearJS has no opinion on how you perform your operations: callbacks, Promises, Generators, ES7 async functions — they'll all work just fine!
 
-If you'd like to jump ahead, you can read more about [async actions](./04-async-actions-and-optimistic-updates.html).
+If you'd like to jump ahead, you can read more about [async actions](./06-async-actions-and-optimistic-updates.html).
 
 Now let's build a few stores.
 


### PR DESCRIPTION
In the docs, the link from the actions page to the async_actions page has a dead link. This should fix that.