### PR TITLE
faster __notify implementation

### DIFF
--- a/src/reactor.js
+++ b/src/reactor.js
@@ -208,15 +208,26 @@ class Reactor {
       })
     })
 
-    observerIdsToNotify.forEach((observerId) => {
-      const entry = this.observerState.getIn(['observersMap', observerId])
-      if (!entry) {
-        // don't notify here in the case a handler called unobserve on another observer
-        return
+    //generates a map with getter as key and an arrays of observer id as value.
+    const getterObserverMap = observerIdsToNotify.reduce((map, observerId) => {
+      const entry = this.observerState.getIn(['observersMap', observerId]);
+      const getter = entry.get('getter');
+      const handler = entry.get('handler');
+
+      let handlerList = map.get(getter);
+
+      if (!handlerList) {
+        handlerList = Immutable.List();
       }
 
-      const getter = entry.get('getter')
-      const handler = entry.get('handler')
+      handlerList = handlerList.push(handler);
+
+      return map.set(getter, handlerList);
+
+    }, Immutable.Map());
+
+    // for each getter, evaluate the getter once, then notify all the observers relies on it
+    getterObserverMap.forEach((handlerList, getter) => {
 
       const prevEvaluateResult = fns.evaluate(this.prevReactorState, getter)
       const currEvaluateResult = fns.evaluate(this.reactorState, getter)
@@ -225,9 +236,10 @@ class Reactor {
       const currValue = currEvaluateResult.result
 
       if (!Immutable.is(prevValue, currValue)) {
-        handler.call(null, currValue)
+        handlerList.forEach(handler => handler.call(null, currValue));
       }
-    })
+
+    });
 
     const nextReactorState = fns.resetDirtyStores(this.reactorState)
 


### PR DESCRIPTION
I've been using the RC branch to tune the performance of our app and found the performance in the current __notify is a bit slow.

The current notify work flow is like the following
* grab every observer from the dirty stores, unified the ids in a set
* evaluate, and compare the difference of the getter value for each of them
* call the handler if the value changed. 

The situation in our app is that we have quite some numbers of observers alive and some of them share the same getter. Not to mention that some of the getter computation takes some time too. Although the new getter value is cached, it still takes time down on the tablet for the current process of __notify.

This pull request tried to group the observer handlers by getter, which results in the following flows
* grab every observer from the dirty stores, unified the ids in a set
* group the handlers by getters
* for each getter, evaluate and compare the difference of the getter value
* if the value is changed, notify all handlers that's listening to it.

The result in our app is quite good after that. Don't know if I breaks anything that I don't know. But for what I see at the moment it's doing its job. 

Thoughts? 
