### PR TITLE
grouping observers by getters in addObserver

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nuclear-js",
   "version": "1.1.2",
   "description": "Immutable, reactive Flux architecture. UI Agnostic.",
-  "main": "src/main.js",
+  "main": "dist/nuclear.js",
   "scripts": {
     "test": "grunt ci"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nuclear-js",
   "version": "1.1.2",
   "description": "Immutable, reactive Flux architecture. UI Agnostic.",
-  "main": "dist/nuclear.js",
+  "main": "src/main.js",
   "scripts": {
     "test": "grunt ci"
   },

--- a/src/reactor.js
+++ b/src/reactor.js
@@ -212,6 +212,9 @@ class Reactor {
       const prevEvaluateResult = fns.evaluate(this.prevReactorState, getter)
       const currEvaluateResult = fns.evaluate(this.reactorState, getter)
 
+      this.prevReactorState = prevEvaluateResult.reactorState
+      this.reactorState = currEvaluateResult.reactorState
+
       const prevValue = prevEvaluateResult.result
       const currValue = currEvaluateResult.result
 

--- a/src/reactor.js
+++ b/src/reactor.js
@@ -208,9 +208,7 @@ class Reactor {
       })
     })
 
-    gettersToNotify.forEach((getterId) => {
-      const getter = this.observerState.get('getters')[getterId];
-
+    gettersToNotify.forEach(getter => {
       const prevEvaluateResult = fns.evaluate(this.prevReactorState, getter)
       const currEvaluateResult = fns.evaluate(this.reactorState, getter)
 
@@ -218,7 +216,7 @@ class Reactor {
       const currValue = currEvaluateResult.result
 
       if (!Immutable.is(prevValue, currValue)) {
-        const handlers = this.observerState.getIn(['gettersMap', getterId])
+        const handlers = this.observerState.getIn(['gettersMap', getter])
           .map(observerId => this.observerState.getIn(['observersMap', observerId, 'handler']))
            // don't notify here in the case a handler called unobserve on another observer
 

--- a/src/reactor/fns.js
+++ b/src/reactor/fns.js
@@ -156,58 +156,53 @@ exports.loadState = function(reactorState, state) {
  */
 exports.addObserver = function(observerState, getter, handler) {
   // use the passed in getter as the key so we can rely on a byreference call for unobserve
-  try {
-    const getterKey = getter
-    if (isKeyPath(getter)) {
-      getter = fromKeyPath(getter)
-    }
-
-    const currId = observerState.get('nextId')
-    const storeDeps = getStoreDeps(getter)
-    const entry = Immutable.Map({
-      id: currId,
-      storeDeps: storeDeps,
-      getterKey: getterKey,
-      getter: getter,
-      handler: handler,
-    })
-
-    let updatedObserverState = observerState.updateIn(['gettersMap', getter]
-      , observerIds =>
-          observerIds
-            ? observerIds.add(currId)
-            : Immutable.Set([]).add(currId)
-    )
-
-    if (storeDeps.size === 0) {
-      // no storeDeps means the observer is dependent on any of the state changing
-
-      updatedObserverState = updatedObserverState.updateIn(['any'], getters => getters.add(getter))
-    } else {
-      updatedObserverState = updatedObserverState.withMutations(map => {
-        storeDeps.forEach(storeId => {
-          map.updateIn(['stores', storeId]
-            , getters =>
-                getters
-                  ? getters.add(getter)
-                  : Immutable.Set([]).add(getter)
-          )
-        })
-      })
-    }
-
-    updatedObserverState = updatedObserverState
-      .set('nextId', currId + 1)
-      .setIn(['observersMap', currId], entry)
-
-    return {
-      observerState: updatedObserverState,
-      entry: entry,
-    }
-  } catch (e) {
-    debugger;
+  const getterKey = getter
+  if (isKeyPath(getter)) {
+    getter = fromKeyPath(getter)
   }
 
+  const currId = observerState.get('nextId')
+  const storeDeps = getStoreDeps(getter)
+  const entry = Immutable.Map({
+    id: currId,
+    storeDeps: storeDeps,
+    getterKey: getterKey,
+    getter: getter,
+    handler: handler,
+  })
+
+  let updatedObserverState = observerState.updateIn(['gettersMap', getter]
+    , observerIds =>
+        observerIds
+          ? observerIds.add(currId)
+          : Immutable.Set([]).add(currId)
+  )
+
+  if (storeDeps.size === 0) {
+    // no storeDeps means the observer is dependent on any of the state changing
+
+    updatedObserverState = updatedObserverState.updateIn(['any'], getters => getters.add(getter))
+  } else {
+    updatedObserverState = updatedObserverState.withMutations(map => {
+      storeDeps.forEach(storeId => {
+        map.updateIn(['stores', storeId]
+          , getters =>
+              getters
+                ? getters.add(getter)
+                : Immutable.Set([]).add(getter)
+        )
+      })
+    })
+  }
+
+  updatedObserverState = updatedObserverState
+    .set('nextId', currId + 1)
+    .setIn(['observersMap', currId], entry)
+
+  return {
+    observerState: updatedObserverState,
+    entry: entry,
+  }
 
 }
 

--- a/src/reactor/records.js
+++ b/src/reactor/records.js
@@ -17,8 +17,6 @@ const ObserverState = Immutable.Record({
   // getters registered to specific store changes
   stores: Immutable.Map({}),
 
-  getters: [],
-
   gettersMap: Immutable.Map({}),
 
   observersMap: Immutable.Map({}),

--- a/src/reactor/records.js
+++ b/src/reactor/records.js
@@ -12,10 +12,14 @@ const ReactorState = Immutable.Record({
 })
 
 const ObserverState = Immutable.Record({
-  // observers registered to any store change
+  // getters registered to any store change
   any: Immutable.Set([]),
-  // observers registered to specific store changes
+  // getters registered to specific store changes
   stores: Immutable.Map({}),
+
+  getters: [],
+
+  gettersMap: Immutable.Map({}),
 
   observersMap: Immutable.Map({}),
 


### PR DESCRIPTION
This PR is a better implementation of the grouping observers by getters idea in 

https://github.com/optimizely/nuclear-js/pull/182

The difference is observers are grouped when they are added. Also the removal of observers has been taken care of too.