### PR TITLE
Fixed observer that registered before store registration might not get notified 

### DIFF
--- a/src/reactor/fns.js
+++ b/src/reactor/fns.js
@@ -382,7 +382,13 @@ function isCached(reactorState, keyPathOrGetter) {
     return false
   }
 
-  return entry.get('storeStates').every((stateId, storeId) => {
+  const storeStates = entry.get('storeStates');
+
+  if(!storeStates || storeStates.size <= 0) {
+    return false;
+  }
+
+  return storeStates.every((stateId, storeId) => {
     return reactorState.getIn(['storeStates', storeId]) === stateId
   })
 }


### PR DESCRIPTION
this is for https://github.com/optimizely/nuclear-js/issues/188

@jordangarcia this is my temporary fix. But I think you will come up with a better solution than this. Coz at the moment the getter for any store will not be cached. 