### PR TITLE
Fix isCached function for empty store states

### DIFF
--- a/src/reactor/fns.js
+++ b/src/reactor/fns.js
@@ -382,7 +382,13 @@ function isCached(reactorState, keyPathOrGetter) {
     return false
   }
 
-  return entry.get('storeStates').every((stateId, storeId) => {
+  const storeStates = entry.get('storeStates')
+  if (storeStates.size === 0) {
+    // if there are no store states for this entry then it was never cached before
+    return false
+  }
+
+  return storeStates.every((stateId, storeId) => {
     return reactorState.getIn(['storeStates', storeId]) === stateId
   })
 }


### PR DESCRIPTION
@lyonlai 

The bug exists when the isCached function thinks that no storeStates
means the entry is cached due to how `Array.prototype.every` works.

this closes #188 and #189 
