### PR TITLE
Correct typo in docs

### DIFF
--- a/docs/src/docs/07-api.md
+++ b/docs/src/docs/07-api.md
@@ -174,7 +174,7 @@ reactor.registerStores({
 })
 ```
 
-#### `Reactor#replacStores(stores)`
+#### `Reactor#replaceStores(stores)`
 
 `stores` - an object of storeId => store instance
 


### PR DESCRIPTION
Changed Reactor#replacStores(stores) to Reactor#replaceStores(stores)