### PR TITLE
Caching stuff

### DIFF
--- a/src/getter.js
+++ b/src/getter.js
@@ -102,6 +102,35 @@ function getStoreDeps(getter) {
   return storeDeps
 }
 
+/**
+ * Add override options to a getter
+ * @param {getter} getter
+ * @param {object} options
+ * @param {boolean} options.useCache
+ * @param {*} options.cacheKey
+ * @returns {getter}
+ */
+function addGetterOptions(getter, options) {
+  if (!isKeyPath(getter) && !isGetter(getter)) {
+    throw new Error('createGetter must be passed a keyPath or Getter')
+  }
+
+  if (getter.hasOwnProperty('__options')) {
+    throw new Error('Cannot reassign options to getter')
+  }
+
+  getter.__options = {}
+
+  if (options.useCache !== undefined) {
+    getter.__options.useCache = !!options.useCache
+  }
+
+  if (options.cacheKey !== undefined) {
+    getter.__options.cacheKey = options.cacheKey
+  }
+  return getter
+}
+
 export default {
   isGetter,
   getComputeFn,
@@ -109,4 +138,5 @@ export default {
   getStoreDeps,
   getDeps,
   fromKeyPath,
+  addGetterOptions,
 }

--- a/src/main.js
+++ b/src/main.js
@@ -4,7 +4,7 @@ import Reactor from './reactor'
 import Immutable from 'immutable'
 import { toJS, toImmutable, isImmutable } from './immutable-helpers'
 import { isKeyPath } from './key-path'
-import { isGetter } from './getter'
+import { isGetter, addGetterOptions } from './getter'
 import createReactMixin from './create-react-mixin'
 
 export default {
@@ -17,4 +17,5 @@ export default {
   toImmutable,
   isImmutable,
   createReactMixin,
+  addGetterOptions,
 }

--- a/src/reactor.js
+++ b/src/reactor.js
@@ -24,9 +24,12 @@ import {
 class Reactor {
   constructor(config = {}) {
     const debug = !!config.debug
+    const itemsToCache = Number(config.maxItemsToCache)
+    const maxItemsToCache = itemsToCache && itemsToCache > 1 ? itemsToCache : null
     const baseOptions = debug ? DEBUG_OPTIONS : PROD_OPTIONS
     const initialReactorState = new ReactorState({
       debug: debug,
+      maxItemsToCache: maxItemsToCache,
       // merge config options with the defaults
       options: baseOptions.merge(config.options || {}),
     })

--- a/src/reactor.js
+++ b/src/reactor.js
@@ -24,6 +24,7 @@ import {
 class Reactor {
   constructor(config = {}) {
     const debug = !!config.debug
+    const useCache = config.useCache === undefined ? true : !!config.useCache
     const itemsToCache = Number(config.maxItemsToCache)
     const maxItemsToCache = itemsToCache && itemsToCache > 1 ? itemsToCache : null
     const baseOptions = debug ? DEBUG_OPTIONS : PROD_OPTIONS
@@ -32,6 +33,7 @@ class Reactor {
       maxItemsToCache: maxItemsToCache,
       // merge config options with the defaults
       options: baseOptions.merge(config.options || {}),
+      useCache: useCache
     })
 
     this.prevReactorState = initialReactorState
@@ -287,6 +289,14 @@ class Reactor {
       }
       this.__isDispatching = false
     }
+  }
+
+  /**
+   * Retrieve cache values
+   *
+   */
+  getCacheValues() {
+    return this.reactorState.get('cache')
   }
 }
 

--- a/src/reactor.js
+++ b/src/reactor.js
@@ -298,6 +298,13 @@ class Reactor {
   getCacheValues() {
     return this.reactorState.get('cache')
   }
+
+  /**
+   * Clear all cached values
+   */
+  clearCacheValues() {
+    this.reactorState = this.reactorState.set('cache', Immutable.Map())
+  }
 }
 
 export default toFactory(Reactor)

--- a/src/reactor.js
+++ b/src/reactor.js
@@ -293,7 +293,7 @@ class Reactor {
 
   /**
    * Retrieve cache values
-   *
+   * @returns {Immutable.Map}
    */
   getCacheValues() {
     return this.reactorState.get('cache')

--- a/src/reactor/fns.js
+++ b/src/reactor/fns.js
@@ -429,6 +429,7 @@ function isCached(reactorState, keyPathOrGetter) {
 function cacheValue(reactorState, getter, value) {
   const hasGetterUseCacheSpecified = getter.__options && getter.__options.useCache !== undefined
 
+  // Prefer getter settings over reactor settings
   if (hasGetterUseCacheSpecified) {
     if (!getter.__options.useCache) {
       return reactorState

--- a/src/reactor/fns.js
+++ b/src/reactor/fns.js
@@ -455,6 +455,12 @@ function cacheValue(reactorState, getter, value) {
   })
 }
 
+/**
+ * Readds the key for the item in cache to update recency
+ * @param {ReactorState} reactorState
+ * @param {cacheKey} cacheKey
+ * @return {ReactorState}
+ */
 function updateCacheRecency(reactorState, cacheKey) {
   return reactorState.withMutations(state => {
     state.deleteIn(['cacheRecency', cacheKey])

--- a/src/reactor/fns.js
+++ b/src/reactor/fns.js
@@ -381,6 +381,9 @@ export function resetDirtyStores(reactorState) {
  * @return {Getter}
  */
 function getCacheKey(getter) {
+  if (getter.__options && getter.__options.cacheKey !== undefined) {
+    return getter.__options.cacheKey
+  }
   return getter
 }
 
@@ -424,6 +427,16 @@ function isCached(reactorState, keyPathOrGetter) {
  * @return {ReactorState}
  */
 function cacheValue(reactorState, getter, value) {
+  const hasGetterUseCacheSpecified = getter.__options && getter.__options.useCache !== undefined
+
+  if (hasGetterUseCacheSpecified) {
+    if (!getter.__options.useCache) {
+      return reactorState
+    }
+  } else if (!reactorState.get('useCache')) {
+    return reactorState
+  }
+
   const cacheKey = getCacheKey(getter)
   const dispatchId = reactorState.get('dispatchId')
   const storeDeps = getStoreDeps(getter)

--- a/src/reactor/records.js
+++ b/src/reactor/records.js
@@ -1,4 +1,4 @@
-import { Map, Set, Record } from 'immutable'
+import { Map, Set, Record, OrderedMap } from 'immutable'
 
 export const PROD_OPTIONS = Map({
   // logs information for each dispatch
@@ -39,10 +39,12 @@ export const ReactorState = Record({
   state: Map(),
   stores: Map(),
   cache: Map(),
+  cacheRecency: OrderedMap(),
   // maintains a mapping of storeId => state id (monotomically increasing integer whenever store state changes)
   storeStates: Map(),
   dirtyStores: Set(),
   debug: false,
+  maxItemsToCache: null,
   // production defaults
   options: PROD_OPTIONS,
 })

--- a/src/reactor/records.js
+++ b/src/reactor/records.js
@@ -47,6 +47,7 @@ export const ReactorState = Record({
   maxItemsToCache: null,
   // production defaults
   options: PROD_OPTIONS,
+  useCache: true,
 })
 
 export const ObserverState = Record({

--- a/tests/getter-tests.js
+++ b/tests/getter-tests.js
@@ -1,4 +1,4 @@
-import { isGetter, getFlattenedDeps, fromKeyPath } from '../src/getter'
+import { isGetter, getFlattenedDeps, fromKeyPath, addGetterOptions } from '../src/getter'
 import { Set, List, is } from 'immutable'
 
 describe('Getter', () => {
@@ -29,6 +29,39 @@ describe('Getter', () => {
       expect(function() {
         fromKeyPath(invalidKeypath)
       }).toThrow()
+    })
+  })
+
+  describe('#addGetterOptions', () => {
+    it('should throw an error if not passed a getter', () => {
+      expect(() => { addGetterOptions('test', {}) }).toThrow()
+    })
+
+    it('should throw an error if options are added more than once', () => {
+      let getter = ['test']
+      getter = addGetterOptions(getter, {})
+      expect(() => { addGetterOptions(getter, {}) }).toThrow()
+    })
+
+    it('should not add options if they are not explicitly supplied or are not valid options', () => {
+      let getter = ['test']
+      getter = addGetterOptions(getter, {})
+      expect(getter.__options).toEqual({})
+      getter = ['test']
+      getter = addGetterOptions(getter, { fakeOption: true })
+      expect(getter.__options).toEqual({})
+    })
+
+    it('should add the use cache option', () => {
+      let getter = ['test']
+      getter = addGetterOptions(getter, { useCache: false })
+      expect(getter.__options.useCache).toBe(false)
+    })
+
+    it('should add the cacheKey option', () => {
+      let getter = ['test']
+      getter = addGetterOptions(getter, { cacheKey: 100 })
+      expect(getter.__options.cacheKey).toBe(100)
     })
   })
 

--- a/tests/reactor-tests.js
+++ b/tests/reactor-tests.js
@@ -612,7 +612,6 @@ describe('Reactor', () => {
         expect(subtotalSpy.calls.count()).toEqual(1)
       })
 
-
       describe('recency caching', () => {
         var getters = Array.from(new Array(100), () => {
           var z = Math.random()
@@ -656,8 +655,6 @@ describe('Reactor', () => {
           expect(cacheReactor.reactorState.get('cacheRecency').size).toBe(Math.floor(CACHE_CLEAR_RATIO * maxItemsToCache) + 1)
           expect(cacheReactor.reactorState.getIn(['cacheRecency', getters[0]])).toBe(undefined)
           expect(cacheReactor.reactorState.getIn(['cacheRecency', getters[50]])).toBe(getters[50])
-
-
         })
       })
     })

--- a/tests/reactor-tests.js
+++ b/tests/reactor-tests.js
@@ -1990,4 +1990,31 @@ describe('Reactor', () => {
       expect(reactor.getCacheValues().get(getter).get('value')).toEqual(1)
     })
   })
+
+
+  describe('#clearCacheValues', () => {
+    let reactor
+    let store1
+    beforeEach(() => {
+      reactor = new Reactor()
+      store1 = new Store({
+        getInitialState: () => 1,
+        initialize() {
+          this.on('increment1', (state) => state + 1)
+        }
+      })
+
+      reactor.registerStores({
+        store1: store1,
+      })
+    })
+
+    it('should return all cached values', () => {
+      let getter = [['test'], () => 1]
+      reactor.evaluate(getter)
+      expect(reactor.getCacheValues().size).toEqual(1)
+      reactor.clearCacheValues()
+      expect(reactor.getCacheValues().toJS()).toEqual({})
+    })
+  })
 })


### PR DESCRIPTION
@jordangarcia @mikeng13 

Added a number of options/functionality around caching including:

1. `getCacheValues` and `clearCacheValues` to `Reactor`. This will allow users to monitor their own cache usage and clear it if need be.
2. `useCache` and `maxItemsToCache` as config options for `Reactor`. This will allow users to disable caching completely, or limit the number of items that are stored in cache. Items are evicted from cache on a standard LRU policy.
3. A utility function for getters, `addOptionsToGetter`, which accepts a getter and augments it with options. Currently supported options are `useCache`, which allows users to specify whether the getter value should be cached on evaluate, and `cacheKey`, which allows users to specify their own cache key.