### PR TITLE
Caching Abstraction

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -23,8 +23,6 @@
     "nuclear-js": "^1.0.5",
     "webpack": "^1.9.11",
     "webpack-dev-server": "^1.9.0",
-    "grunt-concurrent": "^1.0.0",
-    "grunt-contrib-connect": "^0.10.1",
     "remarkable": "^1.6.0",
     "front-matter": "^1.0.0",
     "glob": "^5.0.10",

--- a/src/reactor.js
+++ b/src/reactor.js
@@ -1,6 +1,7 @@
 import Immutable from 'immutable'
 import createReactMixin from './create-react-mixin'
 import * as fns from './reactor/fns'
+import { DefaultCache } from './reactor/cache'
 import { isKeyPath } from './key-path'
 import { isGetter } from './getter'
 import { toJS } from './immutable-helpers'
@@ -27,6 +28,7 @@ class Reactor {
     const baseOptions = debug ? DEBUG_OPTIONS : PROD_OPTIONS
     const initialReactorState = new ReactorState({
       debug: debug,
+      cache: config.cache || DefaultCache(),
       // merge config options with the defaults
       options: baseOptions.merge(config.options || {}),
     })

--- a/src/reactor/cache.js
+++ b/src/reactor/cache.js
@@ -143,6 +143,7 @@ export class LRUCache {
   hit(item) {
     const nextTick = this.tick + 1;
 
+    // if item exists, remove it first to reorder in lru OrderedMap
     const lru = this.cache.lookup(item) ?
       this.lru.remove(item).set(item, nextTick) :
       this.lru;

--- a/src/reactor/cache.js
+++ b/src/reactor/cache.js
@@ -140,12 +140,12 @@ export class LRUCache {
    * @return {LRUCache}
    */
   hit(item) {
-    // if item exists, remove it first to reorder in lru OrderedSet
-    const lru = this.cache.lookup(item) ?
-      this.lru.remove(item).add(item) :
-      this.lru;
+    if (!this.cache.has(item)) {
+      return this;
+    }
 
-    return new LRUCache(this.limit, this.cache, lru)
+    // remove it first to reorder in lru OrderedSet
+    return new LRUCache(this.limit, this.cache, this.lru.remove(item).add(item))
   }
 
   /**

--- a/src/reactor/cache.js
+++ b/src/reactor/cache.js
@@ -15,6 +15,8 @@ export const CacheEntry = Record({
  *    evict(item)
  *    asMap()
  * }
+ *
+ * Inspired by clojure.core.cache/CacheProtocol
  *******************************************************************************/
 
 /**

--- a/src/reactor/cache.js
+++ b/src/reactor/cache.js
@@ -1,0 +1,208 @@
+import { List, Map, OrderedMap, Record } from 'immutable'
+
+export const CacheEntry = Record({
+  value: null,
+  storeStates: Map(),
+  dispatchId: null,
+})
+
+/*******************************************************************************
+ * interface PersistentCache {
+ *    has(item)
+ *    lookup(item, notFoundValue)
+ *    hit(item)
+ *    miss(item, entry)
+ *    evict(item)
+ *    asMap()
+ * }
+ *******************************************************************************/
+
+/**
+ * Plain map-based cache
+ */
+export class BasicCache {
+
+  /**
+   * @param {Immutable.Map} cache
+   */
+  constructor(cache = Map()) {
+    this.cache = cache;
+  }
+
+  /**
+   * Retrieve the associated value, if it exists in this cache, otherwise
+   * returns notFoundValue (or undefined if not provided)
+   * @param {Object} item
+   * @param {Object?} notFoundValue
+   * @return {CacheEntry?}
+   */
+  lookup(item, notFoundValue) {
+    return this.cache.get(item, notFoundValue)
+  }
+
+  /**
+   * Checks if this cache contains an associated value
+   * @param {Object} item
+   * @return {boolean}
+   */
+  has(item) {
+    return this.cache.has(item)
+  }
+
+  /**
+   * Return cached items as map
+   * @return {Immutable.Map}
+   */
+  asMap() {
+    return this.cache
+  }
+
+  /**
+   * Updates this cache when it is determined to contain the associated value
+   * @param {Object} item
+   * @return {BasicCache}
+   */
+  hit(item) {
+    return this;
+  }
+
+  /**
+   * Updates this cache when it is determined to **not** contain the associated value
+   * @param {Object} item
+   * @param {CacheEntry} entry
+   * @return {BasicCache}
+   */
+  miss(item, entry) {
+    return new BasicCache(
+      this.cache.update(item, existingEntry => {
+        if (existingEntry && existingEntry.dispatchId > entry.dispatchId) {
+          throw new Error("Refusing to cache older value")
+        }
+        return entry
+      })
+    )
+  }
+
+  /**
+   * Removes entry from cache
+   * @param {Object} item
+   * @return {BasicCache}
+   */
+  evict(item) {
+    return new BasicCache(this.cache.remove(item))
+  }
+}
+
+/**
+ * Implements caching strategy that evicts least-recently-used items in cache
+ * when an item is being added to a cache that has reached a configured size
+ * limit.
+ */
+export class LRUCache {
+
+  constructor(limit = 1000, cache = new BasicCache(), lru = OrderedMap(), tick = 0) {
+    this.limit = limit;
+    this.cache = cache;
+    this.lru = lru;
+    this.tick = tick;
+  }
+
+  /**
+   * Retrieve the associated value, if it exists in this cache, otherwise
+   * returns notFoundValue (or undefined if not provided)
+   * @param {Object} item
+   * @param {Object?} notFoundValue
+   * @return {CacheEntry}
+   */
+  lookup(item, notFoundValue) {
+    return this.cache.lookup(item, notFoundValue)
+  }
+
+  /**
+   * Checks if this cache contains an associated value
+   * @param {Object} item
+   * @return {boolean}
+   */
+  has(item) {
+    return this.cache.has(item)
+  }
+
+  /**
+   * Return cached items as map
+   * @return {Immutable.Map}
+   */
+  asMap() {
+    return this.cache.asMap()
+  }
+
+  /**
+   * Updates this cache when it is determined to contain the associated value
+   * @param {Object} item
+   * @return {LRUCache}
+   */
+  hit(item) {
+    const nextTick = this.tick + 1;
+
+    const lru = this.cache.lookup(item) ?
+      this.lru.remove(item).set(item, nextTick) :
+      this.lru;
+
+    return new LRUCache(this.limit, this.cache, lru, nextTick)
+  }
+
+  /**
+   * Updates this cache when it is determined to **not** contain the associated value
+   * If cache has reached size limit, the LRU item is evicted.
+   * @param {Object} item
+   * @param {CacheEntry} entry
+   * @return {LRUCache}
+   */
+  miss(item, entry) {
+    const nextTick = this.tick + 1;
+
+    if (this.lru.size >= this.limit) {
+      // TODO add options to clear multiple items at once
+      const evictItem = this.has(item) ? item : this.lru.keySeq().first()
+
+      return new LRUCache(
+        this.limit,
+        this.cache.evict(evictItem).miss(item, entry),
+        this.lru.remove(evictItem).set(item, nextTick),
+        nextTick
+      )
+    } else {
+      return new LRUCache(
+        this.limit,
+        this.cache.miss(item, entry),
+        this.lru.set(item, nextTick),
+        nextTick
+      )
+    }
+  }
+
+  /**
+   * Removes entry from cache
+   * @param {Object} item
+   * @return {LRUCache}
+   */
+  evict(item) {
+    if (!this.cache.has(item)) {
+      return this;
+    }
+
+    return new LRUCache(
+      this.limit,
+      this.cache.evict(item),
+      this.lru.remove(item),
+      this.tick + 1
+    )
+  }
+}
+
+/**
+ * Returns default cache strategy
+ * @return {BasicCache}
+ */
+export function DefaultCache() {
+  return new BasicCache()
+}

--- a/src/reactor/fns.js
+++ b/src/reactor/fns.js
@@ -334,8 +334,8 @@ export function evaluate(reactorState, keyPathOrGetter) {
 
   const cache = reactorState.get('cache')
   var cacheEntry = cache.lookup(keyPathOrGetter)
-  const isCacheMiss = !cacheEntry
-  if (isCacheMiss || isDirtyCacheEntry(reactorState, cacheEntry)) {
+  const isCacheMiss = !cacheEntry || isDirtyCacheEntry(reactorState, cacheEntry)
+  if (isCacheMiss) {
     cacheEntry = createCacheEntry(reactorState, keyPathOrGetter)
   }
 

--- a/src/reactor/records.js
+++ b/src/reactor/records.js
@@ -1,4 +1,5 @@
 import { Map, Set, Record } from 'immutable'
+import { DefaultCache } from './cache'
 
 export const PROD_OPTIONS = Map({
   // logs information for each dispatch
@@ -38,7 +39,7 @@ export const ReactorState = Record({
   dispatchId: 0,
   state: Map(),
   stores: Map(),
-  cache: Map(),
+  cache: DefaultCache(),
   // maintains a mapping of storeId => state id (monotomically increasing integer whenever store state changes)
   storeStates: Map(),
   dirtyStores: Set(),

--- a/tests/cache-tests.js
+++ b/tests/cache-tests.js
@@ -52,14 +52,14 @@ describe('Cache', () => {
 
       cache = cache.miss('e', 5)
 
-      expect(cache.asMap()).toEqual(Map({b: b, d: 4, e: 5}), 'should have have changed')
+      expect(cache.asMap()).toEqual(Map({b: b, d: 4, e: 5}), 'should have changed')
 
       cache = cache.hit('b')
       .hit('e')
       .hit('d')
       .miss('a', 1)
 
-      expect(cache.asMap()).toEqual(Map({a: 1, d: 4, e: 5}), 'should have have changed')
+      expect(cache.asMap()).toEqual(Map({a: 1, d: 4, e: 5}), 'should have changed')
     })
 
     it('should maintain LRU after manual evict', () => {
@@ -121,6 +121,19 @@ describe('Cache', () => {
       .miss('e', 5)
 
       expect(cache.asMap()).toEqual(Map({x: 4, e: 5}))
+    })
+
+    it('should be able to evict multiple LRU items at once', () => {
+      cache = new LRUCache(4, 2)
+      .miss('a', 1)
+      .miss('b', 2)
+      .miss('c', 3)
+      .miss('d', 4)
+      .miss('e', 5)
+
+      expect(cache.asMap()).toEqual(Map({c: 3, d: 4, e: 5}))
+      expect(cache.miss('f', 6).asMap()).toEqual(Map({c: 3, d: 4, e: 5, f: 6}))
+      expect(cache.miss('f', 6).miss('g', 7).asMap()).toEqual(Map({e: 5, f: 6, g: 7}))
     })
   })
 })

--- a/tests/cache-tests.js
+++ b/tests/cache-tests.js
@@ -1,0 +1,126 @@
+import Immutable, { Map } from 'immutable'
+import { toImmutable } from '../src/immutable-helpers'
+import { BasicCache, LRUCache } from '../src/reactor/cache'
+
+
+describe('Cache', () => {
+  describe('LRUCache', () => {
+    var cache
+
+    beforeEach(() => {
+      jasmine.addCustomEqualityTester(Immutable.is)
+    })
+
+    it('should evict least recently used', () => {
+      cache = new LRUCache(3)
+
+      expect(cache.asMap().isEmpty()).toBe(true)
+
+      var a = {foo: "bar"}
+      var b = {bar: "baz"}
+      var c = {baz: "foo"}
+
+      cache = cache.miss('a', a)
+
+      expect(cache.asMap()).toEqual(Map({a: a}))
+      expect(cache.has('a')).toBe(true)
+      expect(cache.lookup('a')).toBe(a)
+
+      cache = cache.miss('b', b)
+      expect(cache.asMap()).toEqual(Map({a: a, b: b}))
+      expect(cache.has('b')).toBe(true)
+      expect(cache.lookup('b')).toBe(b)
+
+      cache = cache.miss('c', c)
+      expect(cache.asMap()).toEqual(Map({a: a, b: b, c: c}))
+      expect(cache.has('c')).toBe(true)
+      expect(cache.lookup('c')).toBe(c)
+
+      expect(cache.has('d')).toBe(false)
+      expect(cache.lookup('d')).not.toBeDefined()
+
+      var notFound = {found: false}
+      expect(cache.lookup('d', notFound)).toBe(notFound)
+
+      cache = cache.miss('d', 4)
+
+      expect(cache.asMap()).toEqual(Map({b: b, c: c, d: 4}), 'a should have been evicted')
+
+      cache = cache.hit('b') // Touch b so its not LRU
+
+      expect(cache.asMap()).toEqual(Map({b: b, c: c, d: 4}), 'should not have have changed')
+
+      cache = cache.miss('e', 5)
+
+      expect(cache.asMap()).toEqual(Map({b: b, d: 4, e: 5}), 'should have have changed')
+
+      cache = cache.hit('b')
+      .hit('e')
+      .hit('d')
+      .miss('a', 1)
+
+      expect(cache.asMap()).toEqual(Map({a: 1, d: 4, e: 5}), 'should have have changed')
+    })
+
+    it('should maintain LRU after manual evict', () => {
+      cache = new LRUCache(3)
+      .miss('a', 'A')
+      .miss('b', 'B')
+      .miss('c', 'C')
+
+      expect(cache.asMap()).toEqual(Map({a: 'A', b: 'B', c: 'C'}))
+
+      cache = cache.evict('a')
+      expect(cache.asMap()).toEqual(Map({b: 'B', c: 'C'}))
+
+      cache = cache.miss('d', 'D')
+      expect(cache.asMap()).toEqual(Map({b: 'B', c: 'C', d: 'D'}))
+    })
+
+    it('should not evict if under limit', () => {
+      cache = new LRUCache(2)
+      .miss('a', 1)
+      .miss('b', 2)
+      .miss('b', 3)
+
+      expect(cache.asMap()).toEqual(Map({a: 1, b: 3}))
+      cache = cache.miss('a', 4)
+      expect(cache.asMap()).toEqual(Map({a: 4, b: 3}))
+
+      cache = new LRUCache(3)
+      .miss('a', 1)
+      .miss('b', 2)
+      .miss('b', 3)
+      .miss('c', 4)
+      .miss('d', 5)
+      .miss('e', 6)
+
+      expect(cache.asMap()).toEqual(Map({e: 6, d: 5, c: 4}))
+    })
+
+    it('should not evict if hitting unknown items', () => {
+      cache = new LRUCache(2)
+      .hit('x')
+      .hit('y')
+      .hit('z')
+      .miss('a', 1)
+      .miss('b', 2)
+      .miss('c', 3)
+      .miss('d', 4)
+      .miss('e', 5)
+
+      expect(cache.asMap()).toEqual(Map({d: 4, e: 5}))
+
+      cache = new LRUCache(2)
+      .hit('x')
+      .hit('y')
+      .miss('a', 1)
+      .miss('b', 2)
+      .miss('y', 3)
+      .miss('x', 4)
+      .miss('e', 5)
+
+      expect(cache.asMap()).toEqual(Map({x: 4, e: 5}))
+    })
+  })
+})

--- a/tests/reactor-tests.js
+++ b/tests/reactor-tests.js
@@ -595,6 +595,24 @@ describe('Reactor', () => {
         expect(taxPercentSpy.calls.count()).toEqual(2)
         expect(subtotalSpy.calls.count()).toEqual(1)
       })
+
+      it('should update cache with updated item after action', () => {
+        const lastItemGetter = [['items', 'all'], (items) => items.last()]
+
+        // ensure its in cache
+        const lastItemBefore = reactor.evaluate(lastItemGetter)
+        const cacheEntryBefore = reactor.reactorState.cache.lookup(lastItemGetter)
+        expect(lastItemBefore === cacheEntryBefore.value).toBe(true)
+
+        checkoutActions.addItem('potato', 0.80)
+
+        const lastItemAfter = reactor.evaluate(lastItemGetter)
+        const cacheEntryAfter = reactor.reactorState.cache.lookup(lastItemGetter)
+        expect(lastItemAfter === cacheEntryAfter.value).toBe(true)
+
+        // sanity check that lastItem actually changed for completeness
+        expect(lastItemAfter !== lastItemBefore).toBe(true)
+      })
     })
 
     describe('#observe', () => {


### PR DESCRIPTION
Introduce a functional caching abstraction. The purpose is to provide extensible
API with abstractions that are composable. Includes implementations for basic
cache strategy (current) and an LRU cache (which wraps BasicCache).

A custom caching strategy can be injected via Reactor constructor.

All existing caching behavior remains the same (for now).

Tangential to #208