### PR TITLE
Combined caching strategy

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -23,8 +23,6 @@
     "nuclear-js": "^1.0.5",
     "webpack": "^1.9.11",
     "webpack-dev-server": "^1.9.0",
-    "grunt-concurrent": "^1.0.0",
-    "grunt-contrib-connect": "^0.10.1",
     "remarkable": "^1.6.0",
     "front-matter": "^1.0.0",
     "glob": "^5.0.10",

--- a/src/console-polyfill.js
+++ b/src/console-polyfill.js
@@ -1,11 +1,11 @@
 try {
-  if (!(window.console && console.log)) {
+  if (!(window.console && console.log)) { // eslint-disable-line
     console = {
-      log: function(){},
-      debug: function(){},
-      info: function(){},
-      warn: function(){},
-      error: function(){}
-    };
+      log: function() {},
+      debug: function() {},
+      info: function() {},
+      warn: function() {},
+      error: function() {},
+    }
   }
-} catch(e) {}
+} catch(e) {} // eslint-disable-line

--- a/src/create-react-mixin.js
+++ b/src/create-react-mixin.js
@@ -26,7 +26,7 @@ export default function(reactor) {
       each(this.getDataBindings(), (getter, key) => {
         const unwatchFn = reactor.observe(getter, (val) => {
           this.setState({
-            [key]: val
+            [key]: val,
           })
         })
 

--- a/src/getter.js
+++ b/src/getter.js
@@ -2,12 +2,49 @@ import Immutable, { List } from 'immutable'
 import { isFunction, isArray } from './utils'
 import { isKeyPath } from './key-path'
 
+const CACHE_OPTIONS = ['default', 'always', 'never']
+
 /**
  * Getter helper functions
  * A getter is an array with the form:
  * [<KeyPath>, ...<KeyPath>, <function>]
  */
 const identity = (x) => x
+
+/**
+ * Add override options to a getter
+ * @param {getter} getter
+ * @param {object} options
+ * @param {boolean} options.cache
+ * @param {*} options.cacheKey
+ * @returns {getter}
+ */
+function Getter(getter, options={}) {
+  if (!isKeyPath(getter) && !isGetter(getter)) {
+    throw new Error('createGetter must be passed a keyPath or Getter')
+  }
+
+  if (getter.hasOwnProperty('__options')) {
+    throw new Error('Cannot reassign options to getter')
+  }
+
+  getter.__options = {}
+  getter.__options.cache = CACHE_OPTIONS.indexOf(options.cache) > -1 ? options.cache : 'default'
+  getter.__options.cacheKey = options.cacheKey !== undefined ? options.cacheKey : null
+  return getter
+}
+
+/**
+ * Retrieve an option from getter options
+ * @param {getter} getter
+ * @param {string} Name of option to retrieve
+ * @returns {*}
+ */
+function getGetterOption(getter, option) {
+  if (getter.__options) {
+    return getter.__options[option]
+  }
+}
 
 /**
  * Checks if something is a getter literal, ex: ['dep1', 'dep2', function(dep1, dep2) {...}]
@@ -106,7 +143,9 @@ export default {
   isGetter,
   getComputeFn,
   getFlattenedDeps,
+  getGetterOption,
   getStoreDeps,
   getDeps,
   fromKeyPath,
+  Getter,
 }

--- a/src/main.js
+++ b/src/main.js
@@ -4,7 +4,7 @@ import Reactor from './reactor'
 import Immutable from 'immutable'
 import { toJS, toImmutable, isImmutable } from './immutable-helpers'
 import { isKeyPath } from './key-path'
-import { isGetter } from './getter'
+import { isGetter, Getter } from './getter'
 import createReactMixin from './create-react-mixin'
 
 export default {
@@ -17,4 +17,5 @@ export default {
   toImmutable,
   isImmutable,
   createReactMixin,
+  Getter,
 }

--- a/src/reactor/cache.js
+++ b/src/reactor/cache.js
@@ -1,0 +1,220 @@
+import { Map, OrderedSet, Record } from 'immutable'
+
+export const CacheEntry = Record({
+  value: null,
+  storeStates: Map(),
+  dispatchId: null,
+})
+
+/*******************************************************************************
+ * interface PersistentCache {
+ *    has(item)
+ *    lookup(item, notFoundValue)
+ *    hit(item)
+ *    miss(item, entry)
+ *    evict(item)
+ *    asMap()
+ * }
+ *
+ * Inspired by clojure.core.cache/CacheProtocol
+ *******************************************************************************/
+
+/**
+ * Plain map-based cache
+ */
+export class BasicCache {
+
+  /**
+   * @param {Immutable.Map} cache
+   */
+  constructor(cache = Map()) {
+    this.cache = cache
+  }
+
+  /**
+   * Retrieve the associated value, if it exists in this cache, otherwise
+   * returns notFoundValue (or undefined if not provided)
+   * @param {Object} item
+   * @param {Object?} notFoundValue
+   * @return {CacheEntry?}
+   */
+  lookup(item, notFoundValue) {
+    return this.cache.get(item, notFoundValue)
+  }
+
+  /**
+   * Checks if this cache contains an associated value
+   * @param {Object} item
+   * @return {boolean}
+   */
+  has(item) {
+    return this.cache.has(item)
+  }
+
+  /**
+   * Return cached items as map
+   * @return {Immutable.Map}
+   */
+  asMap() {
+    return this.cache
+  }
+
+  /**
+   * Updates this cache when it is determined to contain the associated value
+   * @param {Object} item
+   * @return {BasicCache}
+   */
+  hit(item) {
+    return this
+  }
+
+  /**
+   * Updates this cache when it is determined to **not** contain the associated value
+   * @param {Object} item
+   * @param {CacheEntry} entry
+   * @return {BasicCache}
+   */
+  miss(item, entry) {
+    return new BasicCache(
+      this.cache.update(item, existingEntry => {
+        if (existingEntry && existingEntry.dispatchId > entry.dispatchId) {
+          throw new Error('Refusing to cache older value')
+        }
+        return entry
+      })
+    )
+  }
+
+  /**
+   * Removes entry from cache
+   * @param {Object} item
+   * @return {BasicCache}
+   */
+  evict(item) {
+    return new BasicCache(this.cache.remove(item))
+  }
+}
+
+export const DEFAULT_LRU_LIMIT = 1000
+export const DEFAULT_LRU_EVICT_COUNT = 1
+
+/**
+ * Implements caching strategy that evicts least-recently-used items in cache
+ * when an item is being added to a cache that has reached a configured size
+ * limit.
+ */
+export class LRUCache {
+
+  constructor(limit = DEFAULT_LRU_LIMIT, evictCount = DEFAULT_LRU_EVICT_COUNT, cache = new BasicCache(), lru = OrderedSet()) {
+    this.limit = limit
+    this.evictCount = evictCount
+    this.cache = cache
+    this.lru = lru
+  }
+
+  /**
+   * Retrieve the associated value, if it exists in this cache, otherwise
+   * returns notFoundValue (or undefined if not provided)
+   * @param {Object} item
+   * @param {Object?} notFoundValue
+   * @return {CacheEntry}
+   */
+  lookup(item, notFoundValue) {
+    return this.cache.lookup(item, notFoundValue)
+  }
+
+  /**
+   * Checks if this cache contains an associated value
+   * @param {Object} item
+   * @return {boolean}
+   */
+  has(item) {
+    return this.cache.has(item)
+  }
+
+  /**
+   * Return cached items as map
+   * @return {Immutable.Map}
+   */
+  asMap() {
+    return this.cache.asMap()
+  }
+
+  /**
+   * Updates this cache when it is determined to contain the associated value
+   * @param {Object} item
+   * @return {LRUCache}
+   */
+  hit(item) {
+    if (!this.cache.has(item)) {
+      return this
+    }
+
+    // remove it first to reorder in lru OrderedSet
+    return new LRUCache(this.limit, this.evictCount, this.cache, this.lru.remove(item).add(item))
+  }
+
+  /**
+   * Updates this cache when it is determined to **not** contain the associated value
+   * If cache has reached size limit, the LRU item is evicted.
+   * @param {Object} item
+   * @param {CacheEntry} entry
+   * @return {LRUCache}
+   */
+  miss(item, entry) {
+    if (this.lru.size >= this.limit) {
+      if (this.has(item)) {
+        return new LRUCache(
+          this.limit,
+          this.evictCount,
+          this.cache.miss(item, entry),
+          this.lru.remove(item).add(item)
+        )
+      }
+
+      const cache = (this.lru
+                     .take(this.evictCount)
+                     .reduce((c, evictItem) => c.evict(evictItem), this.cache)
+                     .miss(item, entry))
+
+      return new LRUCache(
+        this.limit,
+        this.evictCount,
+        cache,
+        this.lru.skip(this.evictCount).add(item)
+      )
+    }
+    return new LRUCache(
+      this.limit,
+      this.evictCount,
+      this.cache.miss(item, entry),
+      this.lru.add(item)
+    )
+  }
+
+  /**
+   * Removes entry from cache
+   * @param {Object} item
+   * @return {LRUCache}
+   */
+  evict(item) {
+    if (!this.cache.has(item)) {
+      return this
+    }
+
+    return new LRUCache(
+      this.limit,
+      this.evictCount,
+      this.cache.evict(item),
+      this.lru.remove(item)
+    )
+  }
+}
+
+/**
+ * Returns default cache strategy
+ * @return {BasicCache}
+ */
+export function DefaultCache() {
+  return new LRUCache()
+}

--- a/src/reactor/records.js
+++ b/src/reactor/records.js
@@ -1,4 +1,5 @@
 import { Map, Set, Record } from 'immutable'
+import { DefaultCache } from './cache'
 
 export const PROD_OPTIONS = Map({
   // logs information for each dispatch
@@ -38,13 +39,15 @@ export const ReactorState = Record({
   dispatchId: 0,
   state: Map(),
   stores: Map(),
-  cache: Map(),
+  cache: DefaultCache(),
+  cacheFactory: DefaultCache,
   // maintains a mapping of storeId => state id (monotomically increasing integer whenever store state changes)
   storeStates: Map(),
   dirtyStores: Set(),
   debug: false,
   // production defaults
   options: PROD_OPTIONS,
+  useCache: true,
 })
 
 export const ObserverState = Record({

--- a/tests/cache-tests.js
+++ b/tests/cache-tests.js
@@ -1,0 +1,137 @@
+import Immutable, { Map } from 'immutable'
+import { LRUCache } from '../src/reactor/cache'
+
+describe('Cache', () => {
+  describe('LRUCache', () => {
+    var cache
+
+    beforeEach(() => {
+      jasmine.addCustomEqualityTester(Immutable.is)
+    })
+
+    it('should evict least recently used', () => {
+      cache = new LRUCache(3)
+
+      expect(cache.asMap().isEmpty()).toBe(true)
+
+      var a = {foo: 'bar'}
+      var b = {bar: 'baz'}
+      var c = {baz: 'foo'}
+
+      cache = cache.miss('a', a)
+
+      expect(cache.asMap()).toEqual(Map({a: a}))
+      expect(cache.has('a')).toBe(true)
+      expect(cache.lookup('a')).toBe(a)
+
+      cache = cache.miss('b', b)
+      expect(cache.asMap()).toEqual(Map({a: a, b: b}))
+      expect(cache.has('b')).toBe(true)
+      expect(cache.lookup('b')).toBe(b)
+
+      cache = cache.miss('c', c)
+      expect(cache.asMap()).toEqual(Map({a: a, b: b, c: c}))
+      expect(cache.has('c')).toBe(true)
+      expect(cache.lookup('c')).toBe(c)
+
+      expect(cache.has('d')).toBe(false)
+      expect(cache.lookup('d')).not.toBeDefined()
+
+      var notFound = {found: false}
+      expect(cache.lookup('d', notFound)).toBe(notFound)
+
+      cache = cache.miss('d', 4)
+
+      expect(cache.asMap()).toEqual(Map({b: b, c: c, d: 4}), 'a should have been evicted')
+
+      cache = cache.hit('b') // Touch b so its not LRU
+
+      expect(cache.asMap()).toEqual(Map({b: b, c: c, d: 4}), 'should not have have changed')
+
+      cache = cache.miss('e', 5)
+
+      expect(cache.asMap()).toEqual(Map({b: b, d: 4, e: 5}), 'should have changed')
+
+      cache = cache.hit('b')
+      .hit('e')
+      .hit('d')
+      .miss('a', 1)
+
+      expect(cache.asMap()).toEqual(Map({a: 1, d: 4, e: 5}), 'should have changed')
+    })
+
+    it('should maintain LRU after manual evict', () => {
+      cache = new LRUCache(3)
+      .miss('a', 'A')
+      .miss('b', 'B')
+      .miss('c', 'C')
+
+      expect(cache.asMap()).toEqual(Map({a: 'A', b: 'B', c: 'C'}))
+
+      cache = cache.evict('a')
+      expect(cache.asMap()).toEqual(Map({b: 'B', c: 'C'}))
+
+      cache = cache.miss('d', 'D')
+      expect(cache.asMap()).toEqual(Map({b: 'B', c: 'C', d: 'D'}))
+    })
+
+    it('should not evict if under limit', () => {
+      cache = new LRUCache(2)
+      .miss('a', 1)
+      .miss('b', 2)
+      .miss('b', 3)
+
+      expect(cache.asMap()).toEqual(Map({a: 1, b: 3}))
+      cache = cache.miss('a', 4)
+      expect(cache.asMap()).toEqual(Map({a: 4, b: 3}))
+
+      cache = new LRUCache(3)
+      .miss('a', 1)
+      .miss('b', 2)
+      .miss('b', 3)
+      .miss('c', 4)
+      .miss('d', 5)
+      .miss('e', 6)
+
+      expect(cache.asMap()).toEqual(Map({e: 6, d: 5, c: 4}))
+    })
+
+    it('should not evict if hitting unknown items', () => {
+      cache = new LRUCache(2)
+      .hit('x')
+      .hit('y')
+      .hit('z')
+      .miss('a', 1)
+      .miss('b', 2)
+      .miss('c', 3)
+      .miss('d', 4)
+      .miss('e', 5)
+
+      expect(cache.asMap()).toEqual(Map({d: 4, e: 5}))
+
+      cache = new LRUCache(2)
+      .hit('x')
+      .hit('y')
+      .miss('a', 1)
+      .miss('b', 2)
+      .miss('y', 3)
+      .miss('x', 4)
+      .miss('e', 5)
+
+      expect(cache.asMap()).toEqual(Map({x: 4, e: 5}))
+    })
+
+    it('should be able to evict multiple LRU items at once', () => {
+      cache = new LRUCache(4, 2)
+      .miss('a', 1)
+      .miss('b', 2)
+      .miss('c', 3)
+      .miss('d', 4)
+      .miss('e', 5)
+
+      expect(cache.asMap()).toEqual(Map({c: 3, d: 4, e: 5}))
+      expect(cache.miss('f', 6).asMap()).toEqual(Map({c: 3, d: 4, e: 5, f: 6}))
+      expect(cache.miss('f', 6).miss('g', 7).asMap()).toEqual(Map({e: 5, f: 6, g: 7}))
+    })
+  })
+})

--- a/tests/getter-tests.js
+++ b/tests/getter-tests.js
@@ -1,4 +1,4 @@
-import { isGetter, getFlattenedDeps, fromKeyPath } from '../src/getter'
+import { isGetter, getFlattenedDeps, fromKeyPath, getGetterOption, Getter } from '../src/getter'
 import { Set, List, is } from 'immutable'
 
 describe('Getter', () => {
@@ -29,6 +29,58 @@ describe('Getter', () => {
       expect(function() {
         fromKeyPath(invalidKeypath)
       }).toThrow()
+    })
+  })
+
+  describe('#getGetterOption', () => {
+    it('should return undefined if options are not set, or an unrecognized option is requested', () => {
+      expect(getGetterOption(['test'], 'cache')).toBe(undefined)
+      expect(getGetterOption(Getter(['test'], { cache: 'always'}), 'fakeOption')).toBe(undefined)
+    })
+    it('should return the value of the requested option', () => {
+      expect(getGetterOption(Getter(['test'], { cache: 'always'}), 'cache')).toBe('always')
+    })
+  })
+
+  describe('#Getter', () => {
+    it('should throw an error if not passed a getter', () => {
+      expect(() => { Getter(false) }).toThrow()
+    })
+
+    it('should accept a keyPath as a getter argument', () => {
+      const keyPath = ['test']
+      expect(Getter(keyPath)).toBe(keyPath)
+    })
+
+    it('should accept a getter as a getter argument', () => {
+      const getter = ['test', () => 1]
+      expect(Getter(getter)).toBe(getter)
+    })
+
+
+    it('should use "default" as the default cache option', () => {
+      const getterObject = Getter(['test'], {})
+      expect(getGetterOption(getterObject, 'cache')).toBe('default')
+      const getterObject1 = Getter(['test'], { cache: 'fakeOption' })
+      expect(getGetterOption(getterObject1, 'cache')).toBe('default')
+    })
+
+    it('should set "always" and "never" as cache options', () => {
+      const getterObject = Getter(['test'], { cache: 'never' })
+      expect(getGetterOption(getterObject, 'cache')).toBe('never')
+      const getterObject1 = Getter(['test'], { cache: 'always' })
+      expect(getGetterOption(getterObject1, 'cache')).toBe('always')
+    })
+
+    it('should default cacheKey to null', () => {
+      const getterObject = Getter(['test'], {})
+      expect(getGetterOption(getterObject, 'cacheKey')).toBe(null)
+    })
+
+    it('should set cacheKey to supplied value', () => {
+      const getter = ['test']
+      const getterObject = Getter(getter, { cacheKey: 'test' })
+      expect(getGetterOption(getterObject, 'cacheKey')).toBe('test')
     })
   })
 


### PR DESCRIPTION
@jordangarcia @loganlinn 

This includes the changes for the cache abstraction Logan authored and the unwatch/config options I added. API changes include:

1. Config option for `cache`. This expects a cache constructor that conforms to the interface specified in Logan's earlier work.
2. Default to using an LRU cache with a max of 1000 items
3. Config option for `maxItemsToCache`. If not specified, this will default to 1000. If a number > 0, the LRU cache will cache up to `maxItemsToCache` values. If non numeric or `null`, we will default to using a `BasicCache` with no item limit
4. Config option for `useCache` that defaults to true. If false, no cache values will be set.
5. `Getter` pseudo-constructor that can be used to add `cache` and `cacheKey` options for getters. If specified, `cacheKey` will be used as the getter cache key rather than a getter reference. Valid values for `cache` are `['always', 'default', 'never']`. If `'always'` or `'never'` are specified, these options will be favored over the global `useCache` setting.
6. When getters are unobserved, their cached values will be evicted. If getters are unobserved by handler, their corresponding getters caches will be evicted if there are no other handlers associated with the getter