### PR TITLE
Remove ImmutableJS dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "functional",
     "stateless"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "immutable": "^3.7.3"
   },
   "devDependencies": {
@@ -38,6 +38,7 @@
     "grunt-githooks": "^0.3.1",
     "grunt-karma": "^0.12.0",
     "grunt-karma-coveralls": "^2.5.3",
+    "immutable": "^3.7.3",
     "istanbul": "^0.3.15",
     "istanbul-instrumenter-loader": "^0.1.3",
     "jasmine": "^2.3.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,14 @@
 var webpack = require('webpack')
 
+var immutableJS = {
+  immutable: {
+    root: 'Immutable',
+    commonjs2: 'immutable',
+    commonjs: 'immutable',
+    amd: 'immutable',
+  }
+}
+
 var genFilename = function(isMin) {
   return [
     './dist/nuclear',
@@ -23,6 +32,9 @@ module.exports = [
         { test: /\.js$/, exclude: /node_modules/, loader: 'babel-loader' },
       ],
     },
+    externals: [
+      immutableJS
+    ],
   },
   {
     entry: './src/main.js',
@@ -36,6 +48,9 @@ module.exports = [
         { test: /\.js$/, exclude: /node_modules/, loader: 'babel-loader' },
       ],
     },
+    externals: [
+      immutableJS
+    ],
     plugins: [uglifyJsPlugin],
   },
 ]


### PR DESCRIPTION
As discussed in #213 I was able to keep the current codebase and only remove Immutable dependency. Nothing else is touched, so everything should work as expected. Distribution files are not updated, so if you want to test please make sure you recompile them with webpack. Do not forget to install ImmutableJS as a dependecy in `package.json`.