### PR TITLE
Added in support for custom debug logging

### DIFF
--- a/src/logging.js
+++ b/src/logging.js
@@ -3,48 +3,83 @@ import { getOption } from './reactor/fns'
 /* eslint-disable no-console */
 /**
  * Wraps a Reactor.react invocation in a console.group
- * @param {ReactorState} reactorState
- * @param {String} type
- * @param {*} payload
-*/
-exports.dispatchStart = function(reactorState, type, payload) {
-  if (!getOption(reactorState, 'logDispatches')) {
-    return
-  }
-
-  if (console.group) {
-    console.groupCollapsed('Dispatch: %s', type)
-    console.group('payload')
-    console.debug(payload)
-    console.groupEnd()
-  }
-}
-
-exports.dispatchError = function(reactorState, error) {
-  if (!getOption(reactorState, 'logDispatches')) {
-    return
-  }
-
-  if (console.group) {
-    console.debug('Dispatch error: ' + error)
-    console.groupEnd()
-  }
-}
-
-exports.dispatchEnd = function(reactorState, state, dirtyStores) {
-  if (!getOption(reactorState, 'logDispatches')) {
-    return
-  }
-
-  if (console.group) {
-    if (getOption(reactorState, 'logDirtyStores')) {
-      console.log('Stores updated:', dirtyStores.toList().toJS())
+ */
+export const ConsoleGroupLogger = {
+  /**
+   * @param {ReactorState} reactorState
+   * @param {String} type
+   * @param {*} payload
+   */
+  dispatchStart: function(reactorState, type, payload) {
+    if (!getOption(reactorState, 'logDispatches')) {
+      return
     }
 
-    if (getOption(reactorState, 'logAppState')) {
-      console.debug('Dispatch done, new state: ', state.toJS())
+    if (console.group) {
+      console.groupCollapsed('Dispatch: %s', type)
+      console.group('payload')
+      console.debug(payload)
+      console.groupEnd()
     }
-    console.groupEnd()
-  }
+  },
+  /**
+   * @param {ReactorState} reactorState
+   * @param {Error} error
+   */
+  dispatchError: function(reactorState, error) {
+    if (!getOption(reactorState, 'logDispatches')) {
+      return
+    }
+
+    if (console.group) {
+      console.debug('Dispatch error: ' + error)
+      console.groupEnd()
+    }
+  },
+  /**
+   * @param {ReactorState} reactorState
+   * @param {Map} state
+   * @param {Set} dirtyStores
+   */
+  dispatchEnd: function(reactorState, state, dirtyStores) {
+    if (!getOption(reactorState, 'logDispatches')) {
+      return
+    }
+
+    if (console.group) {
+      if (getOption(reactorState, 'logDirtyStores')) {
+        console.log('Stores updated:', dirtyStores.toList().toJS())
+      }
+
+      if (getOption(reactorState, 'logAppState')) {
+        console.debug('Dispatch done, new state: ', state.toJS())
+      }
+      console.groupEnd()
+    }
+  },
 }
+
 /* eslint-enable no-console */
+
+export const NoopLogger = {
+  /**
+   * @param {ReactorState} reactorState
+   * @param {String} type
+   * @param {*} payload
+   */
+  dispatchStart: function(reactorState, type, payload) {
+  },
+  /**
+   * @param {ReactorState} reactorState
+   * @param {Error} error
+   */
+  dispatchError: function(reactorState, error) {
+  },
+  /**
+   * @param {ReactorState} reactorState
+   * @param {Map} state
+   * @param {Set} dirtyStores
+   */
+  dispatchEnd: function(reactorState, state, dirtyStores) {
+  },
+}

--- a/src/reactor.js
+++ b/src/reactor.js
@@ -29,11 +29,14 @@ class Reactor {
     const baseOptions = debug ? DEBUG_OPTIONS : PROD_OPTIONS
     // if defined, merge the custom implementation over the noop logger to avoid undefined lookups,
     // otherwise, just use the built-in console group logger
-    const debugLogger = config.logger ? extend({}, NoopLogger, config.logger) : ConsoleGroupLogger
+    let logger = config.logger ? extend({}, NoopLogger, config.logger) : NoopLogger
+    if (!config.logger && debug) {
+      logger = ConsoleGroupLogger
+    }
     const initialReactorState = new ReactorState({
       debug: debug,
       cache: config.cache || DefaultCache(),
-      logger: debug ? debugLogger : NoopLogger,
+      logger: logger,
       // merge config options with the defaults
       options: baseOptions.merge(config.options || {}),
     })

--- a/src/reactor.js
+++ b/src/reactor.js
@@ -2,10 +2,11 @@ import Immutable from 'immutable'
 import createReactMixin from './create-react-mixin'
 import * as fns from './reactor/fns'
 import { DefaultCache } from './reactor/cache'
+import { NoopLogger, ConsoleGroupLogger } from './logging'
 import { isKeyPath } from './key-path'
 import { isGetter } from './getter'
 import { toJS } from './immutable-helpers'
-import { toFactory } from './utils'
+import { extend, toFactory } from './utils'
 import {
   ReactorState,
   ObserverState,
@@ -26,9 +27,13 @@ class Reactor {
   constructor(config = {}) {
     const debug = !!config.debug
     const baseOptions = debug ? DEBUG_OPTIONS : PROD_OPTIONS
+    // if defined, merge the custom implementation over the noop logger to avoid undefined lookups,
+    // otherwise, just use the built-in console group logger
+    const debugLogger = config.logging ? extend({}, NoopLogger, config.logging) : ConsoleGroupLogger
     const initialReactorState = new ReactorState({
       debug: debug,
       cache: config.cache || DefaultCache(),
+      logging: debug ? debugLogger : NoopLogger,
       // merge config options with the defaults
       options: baseOptions.merge(config.options || {}),
     })

--- a/src/reactor.js
+++ b/src/reactor.js
@@ -29,11 +29,11 @@ class Reactor {
     const baseOptions = debug ? DEBUG_OPTIONS : PROD_OPTIONS
     // if defined, merge the custom implementation over the noop logger to avoid undefined lookups,
     // otherwise, just use the built-in console group logger
-    const debugLogger = config.logging ? extend({}, NoopLogger, config.logging) : ConsoleGroupLogger
+    const debugLogger = config.logger ? extend({}, NoopLogger, config.logger) : ConsoleGroupLogger
     const initialReactorState = new ReactorState({
       debug: debug,
       cache: config.cache || DefaultCache(),
-      logging: debug ? debugLogger : NoopLogger,
+      logger: debug ? debugLogger : NoopLogger,
       // merge config options with the defaults
       options: baseOptions.merge(config.options || {}),
     })

--- a/src/reactor/fns.js
+++ b/src/reactor/fns.js
@@ -73,7 +73,7 @@ export function replaceStores(reactorState, stores) {
  * @return {ReactorState}
  */
 export function dispatch(reactorState, actionType, payload) {
-  let logging = reactorState.get('logging')
+  let logging = reactorState.get('logger')
 
   if (actionType === undefined && getOption(reactorState, 'throwOnUndefinedActionType')) {
     throw new Error('`dispatch` cannot be called with an `undefined` action type.');

--- a/src/reactor/fns.js
+++ b/src/reactor/fns.js
@@ -1,5 +1,4 @@
 import Immutable from 'immutable'
-import logging from '../logging'
 import { CacheEntry } from './cache'
 import { isImmutableValue } from '../immutable-helpers'
 import { toImmutable } from '../immutable-helpers'
@@ -74,6 +73,8 @@ export function replaceStores(reactorState, stores) {
  * @return {ReactorState}
  */
 export function dispatch(reactorState, actionType, payload) {
+  let logging = reactorState.get('logging')
+
   if (actionType === undefined && getOption(reactorState, 'throwOnUndefinedActionType')) {
     throw new Error('`dispatch` cannot be called with an `undefined` action type.');
   }

--- a/src/reactor/records.js
+++ b/src/reactor/records.js
@@ -1,5 +1,6 @@
 import { Map, Set, Record } from 'immutable'
 import { DefaultCache } from './cache'
+import { NoopLogger } from '../logging'
 
 export const PROD_OPTIONS = Map({
   // logs information for each dispatch
@@ -40,6 +41,7 @@ export const ReactorState = Record({
   state: Map(),
   stores: Map(),
   cache: DefaultCache(),
+  logging: NoopLogger,
   // maintains a mapping of storeId => state id (monotomically increasing integer whenever store state changes)
   storeStates: Map(),
   dirtyStores: Set(),

--- a/src/reactor/records.js
+++ b/src/reactor/records.js
@@ -41,7 +41,7 @@ export const ReactorState = Record({
   state: Map(),
   stores: Map(),
   cache: DefaultCache(),
-  logging: NoopLogger,
+  logger: NoopLogger,
   // maintains a mapping of storeId => state id (monotomically increasing integer whenever store state changes)
   storeStates: Map(),
   dirtyStores: Set(),

--- a/tests/reactor-tests.js
+++ b/tests/reactor-tests.js
@@ -78,7 +78,7 @@ describe('Reactor', () => {
       it('should use dispatchStart on the provided logging handler if defined', () => {
         var reactor = new Reactor({
           debug: true,
-          logging: handler,
+          logger: handler,
         })
 
         reactor.dispatch('setTax', 5)
@@ -88,7 +88,7 @@ describe('Reactor', () => {
       it('should use dispatchEnd on the provided logging handler if defined', () => {
         var reactor = new Reactor({
           debug: true,
-          logging: handler,
+          logger: handler,
         })
 
         reactor.dispatch('setTax', 5)
@@ -98,7 +98,7 @@ describe('Reactor', () => {
       it('should use dispatchError on the provided logging handler if defined', () => {
         var reactor = new Reactor({
           debug: true,
-          logging: handler,
+          logger: handler,
           options: {
             throwOnUndefinedActionType: false,
           },
@@ -113,7 +113,7 @@ describe('Reactor', () => {
       it('should use the NoopLogger implementation when a logging function is not defined on the custom implementation', () => {
         var reactor = new Reactor({
           debug: true,
-          logging: {
+          logger: {
             dispatchStart() {},
             dispatchEnd() {},
           },

--- a/tests/reactor-tests.js
+++ b/tests/reactor-tests.js
@@ -3,7 +3,7 @@ import { Reactor, Store } from '../src/main'
 import { getOption } from '../src/reactor/fns'
 import { toImmutable } from '../src/immutable-helpers'
 import { PROD_OPTIONS, DEBUG_OPTIONS } from '../src/reactor/records'
-import logging from '../src/logging'
+import { NoopLogger, ConsoleGroupLogger } from '../src/logging'
 
 describe('Reactor', () => {
   it('should construct without \'new\'', () => {
@@ -53,6 +53,82 @@ describe('Reactor', () => {
       expect(getOption(reactor.reactorState, 'throwOnUndefinedStoreReturnValue')).toBe(true)
       expect(getOption(reactor.reactorState, 'throwOnNonImmutableStore')).toBe(true)
       expect(getOption(reactor.reactorState, 'throwOnDispatchInDispatch')).toBe(false)
+    })
+
+    describe('custom logging', () => {
+      var handler
+
+      beforeEach(() => {
+        handler = {
+          dispatchStart() {},
+          dispatchError() {},
+          dispatchEnd() {},
+        }
+        spyOn(handler, 'dispatchStart')
+        spyOn(handler, 'dispatchError')
+        spyOn(handler, 'dispatchEnd')
+
+        spyOn(NoopLogger, 'dispatchError')
+      })
+
+      afterEach(() => {
+        handler = null
+      })
+
+      it('should use dispatchStart on the provided logging handler if defined', () => {
+        var reactor = new Reactor({
+          debug: true,
+          logging: handler,
+        })
+
+        reactor.dispatch('setTax', 5)
+
+        expect(handler.dispatchStart).toHaveBeenCalled()
+      })
+      it('should use dispatchEnd on the provided logging handler if defined', () => {
+        var reactor = new Reactor({
+          debug: true,
+          logging: handler,
+        })
+
+        reactor.dispatch('setTax', 5)
+
+        expect(handler.dispatchEnd).toHaveBeenCalled()
+      })
+      it('should use dispatchError on the provided logging handler if defined', () => {
+        var reactor = new Reactor({
+          debug: true,
+          logging: handler,
+          options: {
+            throwOnUndefinedActionType: false,
+          },
+        })
+
+        try {
+          reactor.dispatch(undefined)
+        } catch (e) {
+          expect(handler.dispatchError).toHaveBeenCalled()
+        }
+      })
+      it('should use the NoopLogger implementation when a logging function is not defined on the custom implementation', () => {
+        var reactor = new Reactor({
+          debug: true,
+          logging: {
+            dispatchStart() {},
+            dispatchEnd() {},
+          },
+          options: {
+            throwOnUndefinedActionType: false,
+          },
+        })
+
+        try {
+          reactor.dispatch(undefined)
+        } catch (e) {
+          expect(NoopLogger.dispatchError).toHaveBeenCalled()
+        }
+      })
+
     })
   })
 
@@ -1098,7 +1174,7 @@ describe('Reactor', () => {
     var reactor
 
     beforeEach(() => {
-      spyOn(logging, 'dispatchError')
+      spyOn(ConsoleGroupLogger, 'dispatchError')
       var throwingStore = new Store({
         getInitialState() {
           return 1
@@ -1124,7 +1200,7 @@ describe('Reactor', () => {
       expect(function() {
         reactor.dispatch('set', 'foo')
       }).toThrow(new Error('Error during action handling'))
-      expect(logging.dispatchError).toHaveBeenCalledWith(reactor.reactorState, 'Error during action handling')
+      expect(ConsoleGroupLogger.dispatchError).toHaveBeenCalledWith(reactor.reactorState, 'Error during action handling')
     })
   })
 


### PR DESCRIPTION
Added a property to the Reactor constructor object that allows you to pass in your own custom logging implementation.  Tested using the following (in the flux-chat example):
```
const customLogger = {
  dispatchStart: function(reactorState, type, payload) {
    console.log('*************************************')
    console.log('     TYPE: ', type)
    console.log('  PAYLOAD: ', payload)
  },
  dispatchError: function(reactorState, error) {
    console.error(error, reactorState.state.toJS())
  },
  dispatchEnd: function(reactorState, state, dirtyStores) {
    console.log('OLD STATE: ', reactorState.state.toJS())
    console.log('  CHANGED: ', dirtyStores.toList().toJS())
    console.log('NEW STATE: ', state.toJS())
  },
}

module.exports = new Nuclear.Reactor({
  debug: true,
  logger: customLogger,
})
```