### PR TITLE
[Chore] Bump Lodash from 3.X to 4.17.11

### DIFF
--- a/examples/rest-api/package.json
+++ b/examples/rest-api/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "nuclear-js": "^1.0.x",
     "react": "^0.13.0",
-    "lodash": "^3.5.0",
+    "lodash": "^4.17.11",
     "keymirror": "^0.1.1",
     "babel-loader": "^5.3.2"
   },

--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
     "immutable": "^3.8.1"
   },
   "devDependencies": {
-    "grunt": "^0.4.5",
     "babel-core": "^5.8.29",
     "babel-loader": "^5.3.2",
+    "grunt": "^0.4.5",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-eslint": "^14.0.0",
     "grunt-githooks": "^0.3.1",
@@ -54,7 +54,7 @@
     "karma-sauce-launcher": "^0.2.14",
     "karma-webpack": "^1.7.0",
     "load-grunt-config": "^0.17.1",
-    "lodash": "^3.9.3",
+    "lodash": "^4.17.11",
     "node-libs-browser": "^0.5.2",
     "phantomjs": "^1.9.17",
     "react": "^0.13.3",


### PR DESCRIPTION
The version of lodash we're using in our dev dependencies has a security vulnerability. This PR bumps the version to a more secure version. The only lodash feature we're using is `cloneDeep`, so this bump is fairly safe.